### PR TITLE
[ENFLAME] update env and simplify GCU backend compilation

### DIFF
--- a/include/triton_jit/jit_utils.h
+++ b/include/triton_jit/jit_utils.h
@@ -112,6 +112,8 @@ DEFINE_TRITON_TYPE(uint64_t, "u64");
 DEFINE_TRITON_TYPE(float, "fp32");
 DEFINE_TRITON_TYPE(double, "fp64");
 DEFINE_TRITON_TYPE(std::nullptr_t, "*i8");
+DEFINE_TRITON_TYPE(const char*, "constexpr");
+DEFINE_TRITON_TYPE(std::string, "constexpr");
 
 #undef DEFINE_TRITON_TYPE
 

--- a/scripts/standalone_compile.py
+++ b/scripts/standalone_compile.py
@@ -345,18 +345,9 @@ def _compile_a_kernel(
         opts = mlu_backend.parse_options(opts)
         ccinfo = triton.compile(src, target=target, options=opts.__dict__)
     elif backend in ["GCU"]:
-        import triton_gcu.triton
-        from triton_gcu.triton.driver import _GCUDriver
-        from triton_gcu.triton.compiler import _GCUBackend
-        gcu_backends = importlib.import_module('triton.backends')
-        gcu_backends.backends['gcu'] = type('GcuBackendEntry', (), {
-            'compiler': _GCUBackend, 'driver': _GCUDriver
-        })
-        driver = _GCUDriver()
-        target = driver.get_current_target()
-        gcu_backend_inst = triton.compiler.make_backend(target)
-        opts = gcu_backend_inst.parse_options(opts)
-        ccinfo = triton.compile(src, target=target, options=opts.__dict__)
+        from triton.backends.enflame.driver import _GCUDriver
+        target = _GCUDriver().get_current_target()
+        ccinfo = triton.compile(src, target=target, options=opts)
     else:
         # CUDA / IX: use CUDA device context
         with torch.cuda.device(device_id):


### PR DESCRIPTION
- Add DEFINE_TRITON_TYPE for const char* and std::string as constexpr
- Simplify GCU backend in standalone_compile.py to use triton.backends.enflame.driver directly instead of triton_gcu.triton

```
# python tests/run_all_tests.py --backend GCU --build-dir build_gcu --output reports/gcu_with_env.json
Running test: pointwise/add... PASSED (7.42s)
Running test: pointwise/fill... PASSED (7.37s)
Running test: pointwise/fill_... PASSED (7.12s)
Running test: pointwise/zeros... PASSED (7.08s)
Running test: pointwise/exponential_... PASSED (17.03s)
Running test: pointwise/contiguous... PASSED (7.30s)
Running test: reduce/sum... PASSED (6.89s)
Running test: reduce/max... PASSED (6.96s)
Running test: reduce/argmax... PASSED (7.04s)
Running test: reduce/topk... PASSED (5.14s)
Running test: matmul/mm... PASSED (24.22s)
Running test: matmul/bmm... PASSED (7.26s)
Running test: matmul/addmm... PASSED (6.95s)
Running test: index/embedding... PASSED (7.83s)
Running test: index/nonzero... PASSED (4.85s)
Running test: index/cat... PASSED (4.87s)
Running test: index/reshape_and_cache_flash... PASSED (7.38s)
Running test: normalization/softmax... PASSED (6.96s)
Running test: normalization/rms_norm... PASSED (6.99s)
Running test: normalization/fused_add_rms_norm... PASSED (6.89s)
Running test: fusion/apply_rotary_pos_emb... PASSED (7.10s)
Running test: fusion/rwkv_ka_fusion... PASSED (7.50s)
Running test: fusion/rwkv_mm_sparsity... PASSED (7.04s)

============================================================
  Test Summary - GCU Backend
============================================================
  Timestamp: 2026-05-26T13:05:16.401275
  Total:     23
  Passed:    23
  Failed:    0
  Pass Rate: 100.0%
============================================================

Category Breakdown:
  pointwise           : 6/6 (100%)
  reduce              : 4/4 (100%)
  matmul              : 3/3 (100%)
  index               : 4/4 (100%)
  normalization       : 3/3 (100%)
  fusion              : 3/3 (100%)
```
