### PR TITLE
ci: replace standalone Nexus upload with shared build-infra workflow

### DIFF
--- a/.github/workflows/upload-nexus.yml
+++ b/.github/workflows/upload-nexus.yml
@@ -1,3 +1,10 @@
+# Thin caller for the shared Nexus upload workflow.
+#
+# This exact file (no per-repo edits) goes into every FlagOS
+# component repo at .github/workflows/upload-nexus.yml. The upload
+# logic lives in flagos-ai/build-infra; org-level secrets reach it
+# via `secrets: inherit`.
+
 name: Upload to Nexus Repository
 
 on:
@@ -7,101 +14,12 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'Build workflow run ID (optional, uses latest if not specified)'
+        description: 'Build workflow run ID (optional, uses latest successful run if blank)'
         required: false
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download deb build artifacts
-        uses: dawidd6/action-download-artifact@v12
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: build-deb.yml
-          run_id: ${{ github.event.inputs.run_id }}
-          workflow_conclusion: success
-          path: packages/
-
-      - name: Download rpm build artifacts
-        uses: dawidd6/action-download-artifact@v12
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: build-rpm.yml
-          run_id: ${{ github.event.inputs.run_id }}
-          workflow_conclusion: success
-          path: packages/
-        continue-on-error: true
-
-      - name: List downloaded packages
-        run: |
-          echo "Downloaded packages:"
-          find packages/ -name "*.deb" -o -name "*.rpm" | sort
-
-      - name: Upload deb packages to Nexus APT repository
-        env:
-          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          NEXUS_APT_URL: ${{ secrets.NEXUS_APT_URL }}
-        run: |
-          set -e
-
-          upload_deb() {
-            local deb_file="$1"
-            local filename=$(basename "$deb_file")
-            local package=$(dpkg-deb -f "$deb_file" Package)
-            local version=$(dpkg-deb -f "$deb_file" Version)
-            local arch=$(dpkg-deb -f "$deb_file" Architecture)
-
-            echo "Uploading: $filename (${package} ${version} ${arch})"
-
-            if curl -f -u "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" \
-                 --upload-file "$deb_file" \
-                 "${NEXUS_APT_URL}/${filename}"; then
-              echo "  -> OK"
-            else
-              echo "  -> FAILED"
-              return 1
-            fi
-          }
-
-          uploaded=0
-          for deb in $(find packages/ -name "*.deb"); do
-            if upload_deb "$deb"; then
-              ((uploaded++))
-            fi
-          done
-          echo "Uploaded $uploaded deb package(s)"
-
-      - name: Upload rpm packages to Nexus YUM repository
-        env:
-          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          NEXUS_YUM_URL: ${{ secrets.NEXUS_YUM_URL }}
-        run: |
-          set -e
-
-          uploaded=0
-          for rpm in $(find packages/ -name "*.rpm" ! -name "*.src.rpm"); do
-            filename=$(basename "$rpm")
-            echo "Uploading: $filename"
-
-            if curl -f -u "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" \
-                 --upload-file "$rpm" \
-                 "${NEXUS_YUM_URL}/${filename}"; then
-              echo "  -> OK"
-              ((uploaded++))
-            else
-              echo "  -> FAILED"
-            fi
-          done
-          echo "Uploaded $uploaded rpm package(s)"
-
-      - name: Summary
-        run: |
-          echo ""
-          echo "Upload completed!"
-          echo ""
-          echo "Packages uploaded:"
-          find packages/ -name "*.deb" -o -name "*.rpm" | xargs -I{} basename {} | sort
+    uses: flagos-ai/build-infra/.github/workflows/upload-nexus.yml@main
+    with:
+      run_id: ${{ github.event.inputs.run_id }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Replaces the standalone `upload-nexus.yml` with a thin caller of the shared reusable workflow in flagos-ai/build-infra (one workflow, one secret).

## Why

The standalone version reported SUCCESS on runs that uploaded nothing — runs on 2026-05-26/27 hit `curl: (3) URL using bad/illegal format or missing URL` for every artifact (the `NEXUS_APT_URL` / `NEXUS_YUM_URL` secrets were never configured), yet the job exited 0 because `set -e` does not trap a function's `return 1` used inside an `if` condition. Log: run 26499200640.

The shared workflow:
- uses the single org-level `NEXUS_TOKEN` secret (`user:token` for `curl -u`); repo URLs are hardcoded, not secrets
- uploads deb via POST --data-binary to the apt repo root and rpm via PUT (per-format Sonatype methods)
- fails loudly when artifacts are found but none upload

## Depends on

- flagos-ai/build-infra#47 (must merge first — the caller references `@main`)
- org-level `NEXUS_TOKEN` secret configured and shared to this repo

Marked draft until both are in place. After merging, a manual dispatch of this workflow is the end-to-end pilot for the whole rollout.

## Changes

One file: `.github/workflows/upload-nexus.yml` (94 lines → 12 effective lines).