### PR TITLE
ci(packaging): build deb for ubuntu22.04 + cuda12.8 (FlagOS NVIDIA target)

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -21,8 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - base_image: "nvidia/cuda:12.6.0-devel-ubuntu24.04"
-            label: "ubuntu2404-cuda1260"
+          # Match the FlagOS NVIDIA build env (flaggems-nvidia-12.8
+          # container): ubuntu22.04 + cuda12.8 + python3.12. A 22.04
+          # binary also runs on 24.04 (glibc backward-compat); the
+          # reverse does not hold.
+          - base_image: "nvidia/cuda:12.8.0-devel-ubuntu22.04"
+            label: "ubuntu2204-cuda1280"
 
     steps:
       - name: Checkout repository

--- a/packaging/debian/Dockerfile.deb
+++ b/packaging/debian/Dockerfile.deb
@@ -1,32 +1,45 @@
-# Multi-stage Dockerfile to build Debian packages for libtriton-jit
+# Multi-stage Dockerfile to build Debian packages for libtriton-jit.
+#
+# Targets the FlagOS NVIDIA build environment (ubuntu22.04 + cuda12.8 +
+# python3.12 + torch2.10+cu128), matching the flaggems-nvidia-12.8
+# container so the resulting libtriton-jit-dev is ABI-compatible with
+# the FlagGems C++ operator build that consumes it.
+#
+# Ubuntu 22.04 ships cmake 3.22 (< the 3.25 this project requires) and
+# nlohmann-json 3.10.5 (< 3.11.3), so cmake comes from pip and json is
+# fetched at build time (see debian/rules USE_EXTERNAL_JSON=OFF). fmt is
+# fetched too (USE_EXTERNAL_FMTLIB=OFF).
 
-ARG BASE_IMAGE=nvidia/cuda:12.6.0-devel-ubuntu24.04
+ARG BASE_IMAGE=nvidia/cuda:12.8.0-devel-ubuntu22.04
 FROM ${BASE_IMAGE} AS builder
 
+ARG PYTHON_VERSION=3.12
+ARG TORCH_INDEX=https://resource.flagos.net/repository/flagos-pypi-nvidia/simple
+ARG TORCH_PACKAGES="torch==2.10.0+cu128 triton==3.6.0"
+# Cap build parallelism: torch-heavy C++ at full core count OOMs
+# constrained runners (GitHub-hosted runners are ~16 GB).
+ARG BUILD_PARALLEL=4
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Debian packaging tools and build dependencies
-# Ubuntu 24.04 provides cmake 3.28+, nlohmann-json 3.11.3, libfmt 10.2.1
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    cmake \
-    debhelper \
-    devscripts \
-    dpkg-dev \
-    fakeroot \
-    libfmt-dev \
-    ninja-build \
-    nlohmann-json3-dev \
-    patchelf \
-    python3-dev \
-    python3-pip \
-    python3-setuptools \
-    git \
+# Packaging tools + python3.12 (deadsnakes; 22.04 system python is 3.10,
+# but libtriton_jit links pybind11::embed -> libpython, so the python
+# minor must match the consuming container, which is 3.12).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common curl ca-certificates git \
+        build-essential ninja-build patchelf \
+        debhelper devscripts dpkg-dev fakeroot \
+    && add-apt-repository -y ppa:deadsnakes/ppa && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
+    && update-alternatives --install /usr/bin/python  python  /usr/bin/python${PYTHON_VERSION} 1 \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install PyTorch, Triton, and pybind11 via pip
-RUN pip3 install --no-cache-dir --break-system-packages \
-    "torch>=2.5.0" "triton>=3.1.0" "pybind11"
+# pip cmake (>=3.25) + ninja + pybind11, then torch/triton from the
+# FlagOS NVIDIA index (same source the FlagGems container uses).
+RUN python3 -m pip install --no-cache-dir "cmake>=3.25,<4.0" "ninja==1.13.0" "pybind11==3.0.3"
+RUN python3 -m pip install --no-cache-dir --index-url ${TORCH_INDEX} ${TORCH_PACKAGES}
 
 # Copy source code
 COPY . /workspace/libtriton-jit
@@ -37,8 +50,9 @@ RUN if [ -d "packaging/debian" ]; then \
         cp -r packaging/debian debian; \
     fi
 
-# Build the Debian package (-d to skip dep checks, deps are container-provided)
-RUN dpkg-buildpackage -us -uc -b -d || \
+# Build the Debian package (-d to skip dep checks; CUDA/torch deps are
+# container-provided, not apt packages). parallel capped to avoid OOM.
+RUN DEB_BUILD_OPTIONS="parallel=${BUILD_PARALLEL}" dpkg-buildpackage -us -uc -b -d || \
     { echo "Build failed, checking logs..."; \
       find /workspace -name "*.log" -exec echo "=== {} ===" \; -exec cat {} \; 2>/dev/null || true; \
       exit 1; }

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -3,8 +3,11 @@
 export DH_VERBOSE = 1
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
-# Use all available CPU cores for building
-export DEB_BUILD_OPTIONS = parallel=$(shell nproc)
+# Build parallelism: default to all cores, but allow the environment
+# to cap it (torch-heavy C++ at full parallelism OOMs constrained
+# runners — the build container passes parallel=4).
+DEB_BUILD_OPTIONS ?= parallel=$(shell nproc)
+export DEB_BUILD_OPTIONS
 
 %:
 	dh $@
@@ -15,7 +18,7 @@ override_dh_auto_configure:
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DFETCHCONTENT_FULLY_DISCONNECTED=OFF \
 		-DFETCHCONTENT_QUIET=OFF \
-		-DTRITON_JIT_USE_EXTERNAL_JSON=ON \
+		-DTRITON_JIT_USE_EXTERNAL_JSON=OFF \
 		-DTRITON_JIT_USE_EXTERNAL_FMTLIB=OFF \
 		-DTRITON_JIT_USE_EXTERNAL_PYBIND11=ON \
 		-DTRITON_JIT_BUILD_EXAMPLES=OFF \


### PR DESCRIPTION
## Summary

Switches the Debian build to the FlagOS NVIDIA target environment —
ubuntu22.04 + cuda12.8 + python3.12 — so `libtriton-jit-dev` is
ABI-compatible with the FlagGems C++ build that consumes it (the
`flaggems-nvidia-12.8` container). The previous ubuntu24.04/cuda12.6
binary does not install on 22.04 (glibc 2.39 vs 2.35); a 22.04 binary
runs on both.

- `build-deb.yml`: matrix -> `nvidia/cuda:12.8.0-devel-ubuntu22.04` (label `ubuntu2204-cuda1280`).
- `Dockerfile.deb`: python3.12 (deadsnakes), pip cmake (22.04 ships 3.22 < the required 3.25), torch/triton from the FlagOS NVIDIA index.
- `rules`: `USE_EXTERNAL_JSON=OFF` (22.04 ships nlohmann-json 3.10.5 < 3.11.3, so fetch it); `DEB_BUILD_OPTIONS` made env-overridable so the container caps `parallel=4` (full-core parallelism OOMs ~16 GB runners on the torch-linked C++).

## Validation

The build-deb CI on this PR builds the variant. Building FlagGems'
C++ operators against an install of the resulting libtriton-jit-dev
in the matching env was verified separately.
