### PR TITLE
Support string constexpr kernel args; scope googletest to examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,13 +215,15 @@ add_subdirectory(src)
 # ==============================================================================
 # Examples
 # ==============================================================================
-set(INSTALL_GTEST OFF)
-github_url(GTEST_URL "google/googletest/archive/refs/tags/v1.16.0.tar.gz")
-FetchContent_Declare(googletest URL ${GTEST_URL} DOWNLOAD_EXTRACT_TIMESTAMP ON)
-FetchContent_MakeAvailable(googletest)
-
 option(TRITON_JIT_BUILD_EXAMPLES "Build examples" ${PROJECT_IS_TOP_LEVEL})
 if(TRITON_JIT_BUILD_EXAMPLES)
+    # googletest is only needed by the examples; fetch it here so that
+    # subdirectory consumers (e.g. FlagGems via FetchContent) do not pull it in.
+    set(INSTALL_GTEST OFF)
+    github_url(GTEST_URL "google/googletest/archive/refs/tags/v1.16.0.tar.gz")
+    FetchContent_Declare(googletest URL ${GTEST_URL} DOWNLOAD_EXTRACT_TIMESTAMP ON)
+    FetchContent_MakeAvailable(googletest)
+
     add_subdirectory(examples)
 endif()
 

--- a/include/triton_jit/triton_jit_function.h
+++ b/include/triton_jit/triton_jit_function.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
@@ -147,6 +148,16 @@ struct ArgHandle {
       // Assumption: nullopt is always treated as constexpr,
       // even if the parameter is not marked as constexpr
       signature.push_back("nullopt");
+    } else if constexpr (std::is_same_v<std::decay_t<T>, const char*> ||
+                         std::is_same_v<std::decay_t<T>, char*> ||
+                         is_same_ignore_cvref<std::string, T>::value ||
+                         is_same_ignore_cvref<std::string_view, T>::value) {
+      // A string argument (e.g. a dtype spelled "tl.float32") can only ever be
+      // a constexpr Triton parameter. Route it to handle_constexpr at compile
+      // time so the specialized / non-constexpr paths -- which require
+      // triton_type<T>::name and do not specialize for strings -- are never
+      // instantiated for a string type.
+      handle_constexpr(item);
     } else {
       if (ssig.at(idx) == ArgType::CONSTEXPR) {  // constexpr
         handle_constexpr(item);


### PR DESCRIPTION
Two independent fixes surfaced while building FlagGems' C++ operators against this library on the Enflame (GCU) backend.

## 1. String constexpr arguments failed to compile

`ArgHandle::handle_arg_plain()` routes every non-Tensor / non-`nullopt` argument through a **runtime** branch whose handlers (`handle_specialized`, `handle_specialized_no_alignment`, `handle_non_constexpr`) all evaluate `triton_type<T>::name`. For a string argument — e.g. a dtype spelled `"tl.float32"`, passed by FlagGems' GCU `mm` kernel — `triton_type` has no specialization, so the template failed to instantiate:

```
error: 'name' is not a member of 'triton_jit::triton_type<const char*>'
```

even though a string argument is *always* a constexpr Triton parameter at runtime. The CUDA path never passed a string, so it compiled.

**Fix:** add a compile-time `else if constexpr` for `const char*` / `char*` / `std::string` / `std::string_view` that routes strings straight to `handle_constexpr`, mirroring the existing `nullopt` handling, so the specialized / non-constexpr paths are never instantiated for a string type.

## 2. googletest fetched unconditionally

`add_subdirectory(src)` precedes the googletest fetch, so the library itself never needs gtest — only the examples do. But the `FetchContent(googletest)` sat outside the `TRITON_JIT_BUILD_EXAMPLES` guard, so every subdirectory consumer (e.g. FlagGems via `FetchContent`) downloaded googletest anyway.

**Fix:** move the googletest fetch inside the `TRITON_JIT_BUILD_EXAMPLES` block.

## Verification

FlagGems' `flag-gems-cpp-gcu` extension now builds against this library with no string-arg compile error and no googletest download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
