### PR TITLE
fix: relax external fmt version requirement to 8.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,9 @@ endif()
 
 # --- fmtlib ---
 if(TRITON_JIT_USE_EXTERNAL_FMTLIB)
-    find_package(fmt 10.2.1 REQUIRED)
+    # Only fmt::format is used, so any fmt >= 8.1.1 works (the version
+    # shipped by Ubuntu 22.04), no need to require 10.2.1.
+    find_package(fmt 8.1.1 REQUIRED)
 else()
     github_url(FMT_URL "fmtlib/fmt/archive/refs/tags/10.2.1.tar.gz")
     FetchContent_Declare(fmt URL ${FMT_URL} DOWNLOAD_EXTRACT_TIMESTAMP ON)


### PR DESCRIPTION
## Motivation

`CMakeLists.txt` requires `find_package(fmt 10.2.1 REQUIRED)` when `TRITON_JIT_USE_EXTERNAL_FMTLIB=ON`, but the sources only use `fmt::format()` (110 call sites, linked via `fmt::fmt-header-only`) — nothing that needs fmt 10. Ubuntu 22.04 ships fmt **8.1.1**, so with the current floor the external-fmt path is unusable there and builds fall back to the FetchContent-vendored fmt. On the Debian packaging side that vendored fmt gets installed into system paths and forces a `Conflicts: libfmt-dev` on the package.

## Changes

Relax the version floor of the external fmt to `8.1.1` (the vendored FetchContent fallback stays at 10.2.1). With this, Ubuntu 22.04+ can build against the system `libfmt-dev`, and the packaging can drop the vendored fmt install and the `Conflicts: libfmt-dev` (will be handled as a follow-up on the packaging branch).

## Verification

In `nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04` with apt `libfmt-dev 8.1.1+ds1-2`, torch 2.6.0 (cu124):

```
cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
      -DCMAKE_CUDA_ARCHITECTURES=80 -DTRITON_JIT_USE_EXTERNAL_FMTLIB=ON
cmake --build build
```

- configure succeeds resolving the system fmt; `build/_deps/fmt-src` does not exist (no FetchContent fallback triggered);
- `libtriton_jit.so` and all example targets (`test_axpy`, `test_add`, `test_sum` and their op libraries) compile and link successfully (27/27 targets).

The build host has no NVIDIA GPU, so verification covers compile + link; runtime behavior is unchanged since only the accepted version range of the same library is widened.