### PR TITLE
docs: announce multi-backend branch freeze

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Triton JIT C++ runtime
 
+> [!IMPORTANT]
+> **The `multi-backend` branch is frozen.** It has been merged into `master` (#35) and is now read-only — no further contributions are accepted there.
+> **All future development must target `master`.** Please branch from and open pull requests against `master`.
+
 ## Introduction
 
 The `libtriton_jit` project is a multi-backend C++ runtime for Triton JIT functions.


### PR DESCRIPTION
Adds an `[!IMPORTANT]` callout at the top of the README announcing that the **`multi-backend` branch is frozen** (merged into `master` via #35 and now locked read-only), and that **all future development must target `master`**.

Follow-up to the #35 merge + the branch lock. Docs-only change.
