### PR TITLE
docs: note MACA build env requirements (arch list, libstdc++ path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ export MACA_PATH=${MACA_PATH:-/opt/maca}
 export CUCC_PATH=$MACA_PATH/tools/cu-bridge
 export PATH=$CUCC_PATH/tools:$PATH
 export CUCC_CMAKE_ENTRY=2
+# cu-bridge cannot run Caffe2's CUDA compute-arch detection probe (a try_run),
+# so find_package(Torch) fails. Set any value to make it skip detection; the
+# MACA build is CXX-only, so the value does not affect what is compiled.
+export TORCH_CUDA_ARCH_LIST=10.0
+# The mxcc linker does not search the host GCC directory, so `-lstdc++` fails
+# with "cannot find -lstdc++". Add the directory holding libstdc++.so (adjust
+# the GCC version to match your toolchain).
+export LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu/11:$LIBRARY_PATH
 cmake_maca -S . -B build/ -DPython_ROOT="$(which python)/../.." -DBACKEND=MACA
 make_maca -C build/ -j2
 


### PR DESCRIPTION
## What

Documents the two environment settings the MACA (MetaX) backend build needs, alongside the existing MACA steps in the README's "How to build" section. Docs-only — no cmake/build-logic change.

```bash
# cu-bridge can't run Caffe2's CUDA arch-detection try_run -> find_package(Torch) fails
export TORCH_CUDA_ARCH_LIST=10.0
# mxcc's linker doesn't search the host GCC dir -> "cannot find -lstdc++"
export LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu/11:$LIBRARY_PATH
```

## Why

Both were required to build the MACA backend during the post-#35 validation on a MetaX C550. Without `TORCH_CUDA_ARCH_LIST`, `find_package(Torch)` aborts in `select_compute_arch.cmake` (try_run); without the `LIBRARY_PATH` entry, the `mxcc` link of `libtriton_jit.so` fails with `/usr/bin/ld: cannot find -lstdc++`. With both set, the `operators/` suite builds and passes 23/23 on device.

These are toolchain/environment requirements (cu-bridge's arch probe, mxcc's default lib search), so they belong in the build docs rather than in `BackendMACA.cmake`.

Closes #38.
