### PR TITLE
[KMCompiler][NPU] fix: excessive Triton program execution caused by blockNum

### DIFF
--- a/include/triton_jit/backends/npu_backend.h
+++ b/include/triton_jit/backends/npu_backend.h
@@ -185,6 +185,13 @@ struct NpuBackend {
         grid_z,
         workspace_addr ? fmt::format("{}B", opts.workspace_size * blockNum) : "none");
 
+    // Limit blockNum to the available AIV parallel blocks.
+    // Excessive blockNum may cause redundant Triton program execution.
+    uint32_t ai_core_cnt = 0;
+    if (rtGetAiCoreCount(&ai_core_cnt) == RT_ERROR_NONE && ai_core_cnt > 0) {
+      blockNum = std::min(blockNum, ai_core_cnt * 2);
+    }
+
     // Launch kernel
     rtError_t rt_err = rtKernelLaunch(kernel,
                                       blockNum,


### PR DESCRIPTION
Fixes #51

Cap `blockNum` to `rtGetAiCoreCount() * 2` before `rtKernelLaunch`, matching
the behavior of triton-ascend's generated launcher.

Without this cap, `blockNum = grid` can exceed the available AIV blocks and
cause redundant Triton program execution, resulting in severe performance
degradation (up to 109× slowdown in the reproducer).

See the issue for full analysis, reproducer, and profiling evidence.
