### PR TITLE
feat(runtime): support compile options in JIT cache

### DIFF
--- a/include/triton_jit/jit_utils.h
+++ b/include/triton_jit/jit_utils.h
@@ -22,10 +22,13 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <map>
 #include <mutex>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 
 #include "c10/util/Logging.h"  // use torch's logging
 #include "torch/torch.h"
@@ -46,6 +49,62 @@
 #endif
 
 namespace triton_jit {
+
+// Compile-time options threaded from the C++ launch call down to triton.compile.
+// num_warps/num_stages are always part of the compiled artifact; `extra` carries
+// backend-specific compiler switches (e.g. MLU opt_level) as string key/values that
+// the Python bridge coerces to the right type. Every field here participates in the
+// kernel cache key -- see get_kernel in triton_jit_function.cpp.
+struct CompileOptions {
+  int num_warps = 4;
+  int num_stages = 3;
+  std::map<std::string, std::string> extra;
+};
+
+namespace detail {
+
+inline void validate_compile_options(const CompileOptions& opts) {
+  for (const char* reserved : {"num_warps", "num_stages"}) {
+    if (opts.extra.find(reserved) != opts.extra.end()) {
+      throw std::invalid_argument(std::string("CompileOptions.extra must not override reserved option '") +
+                                  reserved + "'");
+    }
+  }
+}
+
+inline void append_cache_key_field(std::string& key, std::string_view value) {
+  key += std::to_string(value.size());
+  key.push_back(':');
+  key.append(value.begin(), value.end());
+}
+
+inline std::string make_kernel_cache_key(std::string_view signature,
+                                         int device_index,
+                                         const CompileOptions& opts) {
+  validate_compile_options(opts);
+
+  std::string key;
+  key.reserve(signature.size() + opts.extra.size() * 24 + 64);
+  key += "sig=";
+  append_cache_key_field(key, signature);
+  key += ";dev=";
+  append_cache_key_field(key, std::to_string(device_index));
+  key += ";nw=";
+  append_cache_key_field(key, std::to_string(opts.num_warps));
+  key += ";ns=";
+  append_cache_key_field(key, std::to_string(opts.num_stages));
+  key += ";extra=";
+  append_cache_key_field(key, std::to_string(opts.extra.size()));
+  for (const auto& [name, value] : opts.extra) {
+    key += ";name=";
+    append_cache_key_field(key, name);
+    key += ";value=";
+    append_cache_key_field(key, value);
+  }
+  return key;
+}
+
+}  // namespace detail
 
 constexpr const char* to_triton_typename(c10::ScalarType t) {
   switch (t) {

--- a/include/triton_jit/triton_jit_function.h
+++ b/include/triton_jit/triton_jit_function.h
@@ -311,6 +311,9 @@ class TritonJITFunctionImpl {
     return this->static_sig_;
   }
 
+  // Backward-compatible overload: plain (num_warps, num_stages) are wrapped into a
+  // CompileOptions carrying no extra switches, then forwarded to the primary overload.
+  // Kept so existing call sites (and operator dispatch code) compile unchanged.
   template <typename... Args>
   void operator()(typename Backend::StreamType stream,
                   unsigned int grid_x,
@@ -318,6 +321,21 @@ class TritonJITFunctionImpl {
                   unsigned int grid_z,
                   unsigned int num_warps,
                   unsigned int num_stages,
+                  Args... args) const {
+    CompileOptions copts;
+    copts.num_warps = static_cast<int>(num_warps);
+    copts.num_stages = static_cast<int>(num_stages);
+    (*this)(stream, grid_x, grid_y, grid_z, copts, args...);
+  }
+
+  // Primary overload: CompileOptions carries num_warps/num_stages plus any extra
+  // backend compiler switches (e.g. {"opt_level","O2"}). All of it feeds the cache key.
+  template <typename... Args>
+  void operator()(typename Backend::StreamType stream,
+                  unsigned int grid_x,
+                  unsigned int grid_y,
+                  unsigned int grid_z,
+                  const CompileOptions& copts,
                   Args... args) const {
     const int num_args = this->static_sig_.num_args;
 
@@ -345,14 +363,14 @@ class TritonJITFunctionImpl {
 
     // Get or compile kernel
     const TritonKernelImpl<Backend>& kernel =
-        this->get_kernel(full_signature, num_warps, num_stages, device_index);
+        this->get_kernel(full_signature, copts, device_index);
 
     // Launch kernel with signature (for NPU backend to parse argument types)
     c10::SmallVector<void*> ptrs = buffer.get_ptrs();
     kernel.launch_with_signature(grid_x,
                                  grid_y,
                                  grid_z,
-                                 num_warps,
+                                 copts.num_warps,
                                  stream,
                                  ptrs.data(),
                                  full_signature,
@@ -371,8 +389,11 @@ class TritonJITFunctionImpl {
     Backend::ensure_context();
     int device_index = Backend::get_device_index();
 
+    CompileOptions copts;
+    copts.num_warps = static_cast<int>(num_warps);
+    copts.num_stages = static_cast<int>(num_stages);
     const TritonKernelImpl<Backend>& kernel =
-        this->get_kernel(full_signature, num_warps, num_stages, device_index);
+        this->get_kernel(full_signature, copts, device_index);
 
     kernel.launch_with_signature(grid_x, grid_y, grid_z, num_warps, stream, args, full_signature, num_args);
   }
@@ -380,8 +401,7 @@ class TritonJITFunctionImpl {
  private:
   TritonJITFunctionImpl(std::string_view path, std::string_view name);
   const TritonKernelImpl<Backend>& get_kernel(std::string_view signature,
-                                              int num_warps,
-                                              int num_stages,
+                                              const CompileOptions& opts,
                                               int device_index) const;
 };
 

--- a/scripts/standalone_compile.py
+++ b/scripts/standalone_compile.py
@@ -236,12 +236,50 @@ def kernel_suffix(signature, specialization):
     return suffix
 
 
+def _coerce_opt(v):
+    """Coerce a string option value coming from the C++ CompileOptions.extra map into
+    the type triton.compile expects (int / float / bool), else keep it as a string.
+    C++ can only hand us strings, but options like num_ctas are ints and some are bools."""
+    if not isinstance(v, str):
+        return v
+    low = v.strip().lower()
+    if low in ("true", "false"):
+        return low == "true"
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        pass
+    return v
+
+
+def _merge_compile_options(
+    num_warps: int,
+    num_stages: int,
+    extra_options: dict = None,
+) -> dict:
+    """Build backend compile options without allowing extras to override core fields."""
+    extra_options = extra_options or {}
+    reserved = sorted({"num_warps", "num_stages"}.intersection(extra_options))
+    if reserved:
+        names = ", ".join(reserved)
+        raise ValueError(f"extra_options must not override reserved option(s): {names}")
+
+    opts = {"num_warps": num_warps, "num_stages": num_stages}
+    opts.update({_k: _coerce_opt(_v) for _k, _v in extra_options.items()})
+    return opts
+
+
 def _compile_a_kernel(
     fn: triton.runtime.JITFunction,
     signature: str,
     num_warps: int = 4,
     num_stages: int = 3,
     device_id: int = 0,
+    extra_options: dict = None,
 ) -> Tuple[str, str]:
     """compile a kernel."""
     # static signature
@@ -373,7 +411,10 @@ def _compile_a_kernel(
     # STEP1: JITFunction, constants, signature, specialization
 
     # STEP2: compile options for the backend
-    opts = {"num_warps": num_warps, "num_stages": num_stages}
+    # Merge backend-specific compiler switches threaded from C++ CompileOptions.extra
+    # (e.g. {"opt_level": "O2"} for MLU). They join `opts` before parse_options so the
+    # backend's own option validation sees them.
+    opts = _merge_compile_options(num_warps, num_stages, extra_options)
 
     # STEP3: ast source, target, compile options (backend-specific)
     backend = get_backend()
@@ -506,6 +547,7 @@ def compile_a_kernel(
     num_warps: int = 4,
     num_stages: int = 3,
     device_id: int = 0,
+    extra_options: dict = None,
 ):
     # get jit function
     source_path = Path(source_path)
@@ -518,7 +560,7 @@ def compile_a_kernel(
     while not (type(fn) is triton.runtime.JITFunction):
         fn = fn.fn
 
-    return _compile_a_kernel(fn, signature, num_warps, num_stages, device_id)
+    return _compile_a_kernel(fn, signature, num_warps, num_stages, device_id, extra_options)
 
 
 if __name__ == "__main__":

--- a/src/triton_jit_function.cpp
+++ b/src/triton_jit_function.cpp
@@ -94,14 +94,20 @@ TritonJITFunctionImpl<Backend>::TritonJITFunctionImpl(std::string_view path, std
 
 template <BackendPolicy Backend>
 const TritonKernelImpl<Backend>& TritonJITFunctionImpl<Backend>::get_kernel(std::string_view _signature,
-                                                                            int num_warps,
-                                                                            int num_stages,
+                                                                            const CompileOptions& opts,
                                                                             int device_index) const {
   std::string signature(_signature);
-  std::string key = fmt::format("{};{}", signature, device_index);
+  // The cache key must encode everything that changes the compiled artifact. The old
+  // key was just "{signature};{device_index}", so two launches that differed only in
+  // num_warps/num_stages/opt_level collided on the same cache entry and the second
+  // silently reused the first one's binary. Fold those compile options into the key.
+  std::string key = detail::make_kernel_cache_key(signature, device_index, opts);
 
   auto pos = this->overloads_.find(key);
   if (pos == this->overloads_.end()) {
+    if (std::getenv("LTJ_DUMP_KEY")) {
+      fmt::print(stderr, "[LTJ_CACHE_MISS] key={}\n", key);
+    }
     // Compile kernel via Python
     namespace py = pybind11;
     ensure_initialized();
@@ -114,7 +120,12 @@ const TritonKernelImpl<Backend>& TritonJITFunctionImpl<Backend>::get_kernel(std:
     py::object fn = mod.attr("compile_a_kernel");
     py::object ans;
     try {
-      ans = fn(this->file_path_, this->function_name_, signature, num_warps, num_stages, device_index);
+      py::dict extra_dict;
+      for (const auto& kv : opts.extra) {
+        extra_dict[py::str(kv.first)] = py::str(kv.second);
+      }
+      ans = fn(this->file_path_, this->function_name_, signature, opts.num_warps, opts.num_stages,
+               device_index, extra_dict);
     } catch (const py::error_already_set& e) {
       std::cerr << "Python exception: " << e.what() << std::endl;
       throw;


### PR DESCRIPTION
## What

Add `CompileOptions{num_warps, num_stages, extra}` to the C++ launch API and forward backend-specific options, such as MLU `opt_level`, to `triton.compile`.

This change also fixes the kernel cache key:

- Include all compile-time options in the key.
- Use deterministic, length-prefixed encoding to prevent key collisions.
- Reject `num_warps` and `num_stages` in `extra` to prevent overriding typed fields.

The existing `(num_warps, num_stages)` API remains backward compatible.

## Why

Compile options affect the generated device binary. If they are missing from the cache key, different configurations may silently reuse the same compiled kernel.

## Testing

Validated on Cambricon MLU590:

- Release build passed.
- 23/23 operator tests passed.
- Python and C++ option/cache-key tests passed.
- `O0`, `O1`, `O2`, `O3`, `Om`, and `Os` compiled and ran correctly.
- Six optimization levels plus one `num_warps` variant produced seven distinct cache entries.
- Repeated configurations correctly hit the cache.
