### PR TITLE
feat(runtime): add process-wide launch hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,14 @@ endif()
 add_subdirectory(src)
 
 # ==============================================================================
+# Unit Tests
+# ==============================================================================
+include(CTest)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
+
+# ==============================================================================
 # Operators with Test Framework
 # ==============================================================================
 option(TRITON_JIT_BUILD_OPERATORS "Build operators with test framework" ${PROJECT_IS_TOP_LEVEL})

--- a/include/triton_jit/triton_kernel.h
+++ b/include/triton_jit/triton_kernel.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -30,6 +32,38 @@
 #include "triton_jit/jit_utils.h"
 
 namespace triton_jit {
+
+// Metadata available at the C++ runtime's kernel dispatch point. Hooks run
+// synchronously, but the strings are owned so callers may safely retain a copy.
+struct LaunchMetadata {
+  std::string kernel_name;
+  unsigned int grid_x = 0;
+  unsigned int grid_y = 0;
+  unsigned int grid_z = 0;
+  int num_warps = 0;
+  unsigned int shared_memory = 0;
+  std::string signature;
+  void* stream = nullptr;
+};
+
+using LaunchHook = std::function<void(const LaunchMetadata&)>;
+
+void set_launch_enter_hook(LaunchHook hook);
+void set_launch_exit_hook(LaunchHook hook);
+void clear_launch_hooks();
+
+namespace detail {
+
+struct LaunchHooksState {
+  LaunchHook enter;
+  LaunchHook exit;
+};
+
+using LaunchHooksSnapshot = std::shared_ptr<const LaunchHooksState>;
+
+LaunchHooksSnapshot get_launch_hooks_snapshot();
+
+}  // namespace detail
 
 // Forward declaration
 template <BackendPolicy Backend>
@@ -97,6 +131,27 @@ class TritonKernelImpl {
     // Prepare backend-specific launch options (no branching)
     auto opts = Backend::prepare_launch(dir_, kernel_name_, shared_memory, signature, num_args);
 
+    // Take one immutable snapshot for the whole launch. Updating or clearing the
+    // process-wide hooks from another thread (or from a hook itself) only affects
+    // subsequent launches.
+    detail::LaunchHooksSnapshot hooks = detail::get_launch_hooks_snapshot();
+    LaunchMetadata metadata;
+    if (hooks) {
+      metadata.kernel_name = kernel_name_;
+      metadata.grid_x = grid_x;
+      metadata.grid_y = grid_y;
+      metadata.grid_z = grid_z;
+      metadata.num_warps = num_warps;
+      metadata.shared_memory = shared_memory;
+      metadata.signature = signature;
+      if constexpr (std::is_pointer_v<typename Backend::StreamType>) {
+        metadata.stream = reinterpret_cast<void*>(stream);
+      }
+      if (hooks->enter) {
+        hooks->enter(metadata);
+      }
+    }
+
     // Launch kernel using backend policy (unified interface)
     Backend::launch_kernel(stream,
                            kernel_handle_,
@@ -108,6 +163,10 @@ class TritonKernelImpl {
                            block_z,
                            args,
                            opts);
+
+    if (hooks && hooks->exit) {
+      hooks->exit(metadata);
+    }
   }
 
   const std::string& get_dir() const {

--- a/include/triton_jit/triton_kernel.h
+++ b/include/triton_jit/triton_kernel.h
@@ -43,11 +43,22 @@ struct LaunchMetadata {
   int num_warps = 0;
   unsigned int shared_memory = 0;
   std::string signature;
+  // Null when Backend::StreamType is not pointer-representable.
   void* stream = nullptr;
 };
 
+// Hooks execute synchronously on the launching thread and may be invoked
+// concurrently by multiple launch threads. Callbacks are responsible for
+// synchronizing their own state.
+//
+// Exceptions propagate to the caller. If enter throws, the kernel is not
+// submitted. Exit runs only after Backend::launch_kernel returns successfully;
+// if exit throws, the kernel has already been submitted.
 using LaunchHook = std::function<void(const LaunchMetadata&)>;
 
+// Hook updates affect subsequent launches. An in-flight launch retains the
+// immutable enter/exit snapshot acquired before invoking enter, so a hook may
+// safely update or clear the process-wide hooks.
 void set_launch_enter_hook(LaunchHook hook);
 void set_launch_exit_hook(LaunchHook hook);
 void clear_launch_hooks();

--- a/packaging/rpm/libtriton-jit.spec
+++ b/packaging/rpm/libtriton-jit.spec
@@ -47,6 +47,7 @@ TORCH_CMAKE_PATH=$(python3 -c "import importlib.util; s=importlib.util.find_spec
     -DTRITON_JIT_USE_EXTERNAL_FMTLIB=OFF \
     -DTRITON_JIT_USE_EXTERNAL_PYBIND11=ON \
     -DTRITON_JIT_BUILD_OPERATORS=OFF \
+    -DBUILD_TESTING=OFF \
     -DTRITON_JIT_INSTALL=ON
 
 %cmake_build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@
 # the cxx flags from torch, so we just merge then as one target, for simplicity
 # then it can use the same cxx flags with public dependency transitivity
 # --------------------------- triton jit function ---------------------------
-add_library(triton_jit SHARED triton_jit_function.cpp jit_utils.cpp kernel_metadata.cpp)
+add_library(triton_jit SHARED triton_jit_function.cpp jit_utils.cpp kernel_metadata.cpp launch_hooks.cpp)
 target_include_directories(triton_jit
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/src/launch_hooks.cpp
+++ b/src/launch_hooks.cpp
@@ -1,0 +1,80 @@
+// Copyright 2026 FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "triton_jit/triton_kernel.h"
+
+#include <memory>
+#include <utility>
+
+namespace triton_jit {
+namespace {
+
+detail::LaunchHooksSnapshot launch_hooks;
+
+template <typename Update>
+void update_launch_hooks(Update&& update) {
+  detail::LaunchHooksSnapshot current =
+      std::atomic_load_explicit(&launch_hooks, std::memory_order_acquire);
+  while (true) {
+    auto next = std::make_shared<detail::LaunchHooksState>();
+    if (current) {
+      *next = *current;
+    }
+    update(*next);
+
+    detail::LaunchHooksSnapshot desired;
+    if (next->enter || next->exit) {
+      desired = std::move(next);
+    }
+
+    if (std::atomic_compare_exchange_weak_explicit(&launch_hooks,
+                                                   &current,
+                                                   desired,
+                                                   std::memory_order_acq_rel,
+                                                   std::memory_order_acquire)) {
+      return;
+    }
+  }
+}
+
+}  // namespace
+
+namespace detail {
+
+LaunchHooksSnapshot get_launch_hooks_snapshot() {
+  return std::atomic_load_explicit(&launch_hooks, std::memory_order_acquire);
+}
+
+}  // namespace detail
+
+void set_launch_enter_hook(LaunchHook hook) {
+  update_launch_hooks([&hook](detail::LaunchHooksState& hooks) { hooks.enter = hook; });
+}
+
+void set_launch_exit_hook(LaunchHook hook) {
+  update_launch_hooks([&hook](detail::LaunchHooksState& hooks) { hooks.exit = hook; });
+}
+
+void clear_launch_hooks() {
+  std::atomic_store_explicit(
+      &launch_hooks, detail::LaunchHooksSnapshot {}, std::memory_order_release);
+}
+
+}  // namespace triton_jit

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(test_launch_hooks test_launch_hooks.cpp)
+target_link_libraries(test_launch_hooks PRIVATE TritonJIT::triton_jit)
+add_test(NAME launch_hooks COMMAND test_launch_hooks)

--- a/tests/test_launch_hooks.cpp
+++ b/tests/test_launch_hooks.cpp
@@ -1,0 +1,270 @@
+// Copyright 2026 FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "triton_jit/triton_kernel.h"
+
+#include <atomic>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+namespace {
+
+void check(bool condition, const char* expression, int line) {
+  if (!condition) {
+    throw std::runtime_error("check failed at line " + std::to_string(line) + ": " + expression);
+  }
+}
+
+#define REQUIRE(expression) check(static_cast<bool>(expression), #expression, __LINE__)
+
+struct HooksGuard {
+  HooksGuard() {
+    triton_jit::clear_launch_hooks();
+  }
+
+  ~HooksGuard() {
+    triton_jit::clear_launch_hooks();
+  }
+};
+
+struct FakeBackend {
+  using StreamType = void*;
+  using ContextType = void*;
+  using KernelHandle = int;
+  using LaunchOptions = int;
+
+  static constexpr unsigned int WARP_SIZE = 32;
+  inline static std::atomic<int> launch_count {0};
+  inline static std::atomic<bool> throw_on_launch {false};
+
+  static void launch_kernel(StreamType,
+                            KernelHandle,
+                            unsigned,
+                            unsigned,
+                            unsigned,
+                            unsigned,
+                            unsigned,
+                            unsigned,
+                            void**,
+                            const LaunchOptions&) {
+    ++launch_count;
+    if (throw_on_launch.load()) {
+      throw std::runtime_error("backend launch failed");
+    }
+  }
+
+  static void ensure_context() {
+  }
+
+  static int get_device_index() {
+    return 0;
+  }
+
+  static KernelHandle load_kernel(const std::string&, const std::string&) {
+    return 1;
+  }
+
+  static unsigned int get_shared_memory(const std::string&, const std::string&) {
+    return 128;
+  }
+
+  static LaunchOptions prepare_launch(const std::string&,
+                                      const std::string&,
+                                      unsigned int,
+                                      const std::string&,
+                                      size_t) {
+    return 0;
+  }
+
+  static void reset() {
+    launch_count = 0;
+    throw_on_launch = false;
+  }
+};
+
+static_assert(triton_jit::BackendPolicy<FakeBackend>);
+
+using FakeKernel = triton_jit::TritonKernelImpl<FakeBackend>;
+
+void test_setters_preserve_both_hooks() {
+  HooksGuard guard;
+  triton_jit::set_launch_enter_hook([](const triton_jit::LaunchMetadata&) {});
+  triton_jit::set_launch_exit_hook([](const triton_jit::LaunchMetadata&) {});
+
+  auto snapshot = triton_jit::detail::get_launch_hooks_snapshot();
+  REQUIRE(snapshot);
+  REQUIRE(snapshot->enter);
+  REQUIRE(snapshot->exit);
+}
+
+void test_clear_removes_snapshot() {
+  HooksGuard guard;
+  triton_jit::set_launch_enter_hook([](const triton_jit::LaunchMetadata&) {});
+  triton_jit::clear_launch_hooks();
+
+  REQUIRE(!triton_jit::detail::get_launch_hooks_snapshot());
+}
+
+void test_concurrent_setters_do_not_lose_updates() {
+  HooksGuard guard;
+  for (int iteration = 0; iteration < 1000; ++iteration) {
+    triton_jit::clear_launch_hooks();
+
+    std::thread enter([] {
+      triton_jit::set_launch_enter_hook([](const triton_jit::LaunchMetadata&) {});
+    });
+    std::thread exit([] {
+      triton_jit::set_launch_exit_hook([](const triton_jit::LaunchMetadata&) {});
+    });
+    enter.join();
+    exit.join();
+
+    auto snapshot = triton_jit::detail::get_launch_hooks_snapshot();
+    REQUIRE(snapshot);
+    REQUIRE(snapshot->enter);
+    REQUIRE(snapshot->exit);
+  }
+}
+
+void test_reentrant_clear_keeps_current_snapshot() {
+  HooksGuard guard;
+  FakeBackend::reset();
+  int enter_count = 0;
+  int exit_count = 0;
+  int stream_token = 0;
+  void* stream = &stream_token;
+  triton_jit::LaunchMetadata captured;
+
+  triton_jit::set_launch_enter_hook([&](const triton_jit::LaunchMetadata& metadata) {
+    ++enter_count;
+    captured = metadata;
+    triton_jit::clear_launch_hooks();
+  });
+  triton_jit::set_launch_exit_hook(
+      [&](const triton_jit::LaunchMetadata&) { ++exit_count; });
+
+  FakeKernel kernel("unused", "fake_kernel");
+  kernel.launch_with_signature(2, 3, 4, 5, stream, nullptr, "*fp32:16,i32", 2);
+
+  REQUIRE(enter_count == 1);
+  REQUIRE(exit_count == 1);
+  REQUIRE(FakeBackend::launch_count == 1);
+  REQUIRE(captured.kernel_name == "fake_kernel");
+  REQUIRE(captured.grid_x == 2);
+  REQUIRE(captured.grid_y == 3);
+  REQUIRE(captured.grid_z == 4);
+  REQUIRE(captured.num_warps == 5);
+  REQUIRE(captured.shared_memory == 128);
+  REQUIRE(captured.signature == "*fp32:16,i32");
+  REQUIRE(captured.stream == stream);
+
+  kernel.launch_with_signature(1, 1, 1, 1, stream, nullptr, "", 0);
+  REQUIRE(enter_count == 1);
+  REQUIRE(exit_count == 1);
+  REQUIRE(FakeBackend::launch_count == 2);
+}
+
+void test_enter_exception_prevents_launch() {
+  HooksGuard guard;
+  FakeBackend::reset();
+  int exit_count = 0;
+
+  triton_jit::set_launch_enter_hook(
+      [](const triton_jit::LaunchMetadata&) { throw std::runtime_error("enter failed"); });
+  triton_jit::set_launch_exit_hook(
+      [&](const triton_jit::LaunchMetadata&) { ++exit_count; });
+
+  bool caught = false;
+  try {
+    FakeKernel("unused", "fake_kernel").launch(1, 1, 1, 1, nullptr, nullptr);
+  } catch (const std::runtime_error& error) {
+    caught = std::string(error.what()) == "enter failed";
+  }
+
+  REQUIRE(caught);
+  REQUIRE(FakeBackend::launch_count == 0);
+  REQUIRE(exit_count == 0);
+}
+
+void test_backend_exception_skips_exit() {
+  HooksGuard guard;
+  FakeBackend::reset();
+  FakeBackend::throw_on_launch = true;
+  int enter_count = 0;
+  int exit_count = 0;
+
+  triton_jit::set_launch_enter_hook(
+      [&](const triton_jit::LaunchMetadata&) { ++enter_count; });
+  triton_jit::set_launch_exit_hook(
+      [&](const triton_jit::LaunchMetadata&) { ++exit_count; });
+
+  bool caught = false;
+  try {
+    FakeKernel("unused", "fake_kernel").launch(1, 1, 1, 1, nullptr, nullptr);
+  } catch (const std::runtime_error& error) {
+    caught = std::string(error.what()) == "backend launch failed";
+  }
+
+  REQUIRE(caught);
+  REQUIRE(FakeBackend::launch_count == 1);
+  REQUIRE(enter_count == 1);
+  REQUIRE(exit_count == 0);
+}
+
+void test_exit_exception_follows_launch() {
+  HooksGuard guard;
+  FakeBackend::reset();
+
+  triton_jit::set_launch_exit_hook(
+      [](const triton_jit::LaunchMetadata&) { throw std::runtime_error("exit failed"); });
+
+  bool caught = false;
+  try {
+    FakeKernel("unused", "fake_kernel").launch(1, 1, 1, 1, nullptr, nullptr);
+  } catch (const std::runtime_error& error) {
+    caught = std::string(error.what()) == "exit failed";
+  }
+
+  REQUIRE(caught);
+  REQUIRE(FakeBackend::launch_count == 1);
+}
+
+}  // namespace
+
+int main() {
+  try {
+    test_setters_preserve_both_hooks();
+    test_clear_removes_snapshot();
+    test_concurrent_setters_do_not_lose_updates();
+    test_reentrant_clear_keeps_current_snapshot();
+    test_enter_exception_prevents_launch();
+    test_backend_exception_skips_exit();
+    test_exit_exception_follows_launch();
+  } catch (const std::exception& error) {
+    std::cerr << "launch hook test failed: " << error.what() << '\n';
+    return 1;
+  }
+
+  std::cout << "launch hook tests passed\n";
+  return 0;
+}


### PR DESCRIPTION
## What

  Add process-wide enter/exit hooks around the C++ kernel dispatch path.

  Hook state lives in `libtriton_jit.so` and is accessed through immutable atomic snapshots, supporting concurrent launches, hook updates, re-entrant clearing, and cross-DSO usage.

  `LaunchMetadata` provides the kernel name, grid, warps, shared memory, signature, and stream. Owned string fields may be retained after the callback returns.

  ## Why

  The C++ runtime dispatches kernels directly and bypasses Triton's Python launcher, making Python launch hooks unable to observe these launches.

  This change provides an equivalent observation point for profilers, tracers, and counters.

  ## Testing

  - Hardware-independent CTest covers hook registration, clearing, concurrent updates, re-entrant clearing, metadata, and exception semantics.
  - Full Release build passed on Cambricon MLU590.
  - 23/23 MLU operator tests passed.
  - Cross-DSO hook sharing passed.
  - MLU launch metadata, including the default/null stream value, was captured as expected.
  - 10,000 launches triggered exactly 10,000 enter and 10,000 exit callbacks.


## Packaging

RPM builds set BUILD_TESTING=OFF, so packaging builds only the production libtriton_jit.so and does not link the CTest executable against optional CUDA test dependencies. Hook tests remain available to developer and CI builds configured with BUILD_TESTING=ON.