### PR TITLE
feat(runtime): support tuple arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,9 +68,6 @@ CLAUDE.md
 AGENTS.md
 .claude/
 
-# Tests (run locally only)
-tests/
-
 # local build outputs
 output/
 debian-packages/

--- a/include/triton_jit/backends/npu_arg_buffer.h
+++ b/include/triton_jit/backends/npu_arg_buffer.h
@@ -22,8 +22,9 @@
 
 #include <cctype>
 #include <cstring>
-#include <sstream>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "c10/util/Logging.h"
@@ -142,52 +143,110 @@ class NpuArgBuffer {
  * - "nullopt" is skipped
  * - "true"/"false" are boolean constexpr (skipped)
  */
-inline std::vector<NpuArgInfo> parse_signature(const std::string& sig) {
-  std::vector<NpuArgInfo> layout;
-  std::stringstream ss(sig);
-  std::string token;
+inline std::string trim_signature_token(std::string_view token) {
+  const size_t start = token.find_first_not_of(" \t");
+  if (start == std::string_view::npos) {
+    return "";
+  }
+  const size_t end = token.find_last_not_of(" \t");
+  return std::string(token.substr(start, end - start + 1));
+}
 
-  while (std::getline(ss, token, ',')) {
-    size_t start = token.find_first_not_of(" \t");
-    size_t end = token.find_last_not_of(" \t");
-    if (start == std::string::npos) continue;
-    token = token.substr(start, end - start + 1);
+inline std::vector<std::string> split_signature_tokens(std::string_view signature) {
+  std::vector<std::string> tokens;
+  size_t token_start = 0;
+  int depth = 0;
 
-    if (token.empty()) continue;
-    if (token == "nullopt") continue;
-    if (token == "true" || token == "false") continue;  // boolean constexpr
-
-    bool is_number = !token.empty() && (std::isdigit(token[0]) ||
-                                        (token[0] == '-' && token.size() > 1 && std::isdigit(token[1])));
-    if (is_number) continue;
-
-    size_t colon_pos = token.find(':');
-    if (colon_pos != std::string::npos) {
-      token = token.substr(0, colon_pos);
+  for (size_t i = 0; i < signature.size(); ++i) {
+    const char ch = signature[i];
+    if (ch == '(') {
+      ++depth;
+    } else if (ch == ')') {
+      if (depth == 0) {
+        throw std::invalid_argument("Unmatched ')' in signature");
+      }
+      --depth;
+    } else if (ch == ',' && depth == 0) {
+      std::string token = trim_signature_token(signature.substr(token_start, i - token_start));
+      if (token.empty()) {
+        throw std::invalid_argument("Empty token in signature");
+      }
+      tokens.push_back(std::move(token));
+      token_start = i + 1;
     }
-
-    NpuArgInfo info;
-
-    if (token[0] == '*') {
-      info.type = NpuArgType::POINTER;
-    } else if (token.substr(0, 3) == "i64" || token.substr(0, 3) == "u64") {
-      info.type = NpuArgType::I64;
-    } else if (token.substr(0, 3) == "i32" || token.substr(0, 3) == "u32") {
-      info.type = NpuArgType::I32;
-    } else if (token.substr(0, 4) == "fp64" || token.substr(0, 3) == "f64") {
-      info.type = NpuArgType::F64;
-    } else if (token.substr(0, 4) == "fp32" || token.substr(0, 3) == "f32") {
-      info.type = NpuArgType::F32;
-    } else if (token.substr(0, 4) == "fp16" || token.substr(0, 3) == "f16" || token.substr(0, 4) == "bf16") {
-      info.type = NpuArgType::F32;
-    } else {
-      LOG(WARNING) << "Unknown type in signature: " << token << ", defaulting to i64";
-      info.type = NpuArgType::I64;
-    }
-
-    layout.push_back(info);
   }
 
+  if (depth != 0) {
+    throw std::invalid_argument("Unmatched '(' in signature");
+  }
+
+  std::string final_token = trim_signature_token(signature.substr(token_start));
+  if (!final_token.empty()) {
+    tokens.push_back(std::move(final_token));
+  } else if (!tokens.empty()) {
+    throw std::invalid_argument("Empty token in signature");
+  }
+  return tokens;
+}
+
+inline void append_signature_token(std::string token, std::vector<NpuArgInfo>& layout) {
+  if (token.starts_with('(') && token.ends_with(')')) {
+    std::string_view inner(token.data() + 1, token.size() - 2);
+    if (trim_signature_token(inner).empty()) {
+      throw std::invalid_argument("Runtime tuple signature must not be empty");
+    }
+    for (std::string element : split_signature_tokens(inner)) {
+      if (element.find_first_of("()") != std::string::npos) {
+        throw std::invalid_argument("Nested runtime tuple signatures are not supported");
+      }
+      append_signature_token(std::move(element), layout);
+    }
+    return;
+  }
+
+  if (token == "nullopt" || token == "true" || token == "false") {
+    return;
+  }
+
+  const bool is_number =
+      std::isdigit(static_cast<unsigned char>(token[0])) ||
+      (token[0] == '-' && token.size() > 1 &&
+       std::isdigit(static_cast<unsigned char>(token[1])));
+  if (is_number) {
+    return;
+  }
+
+  const size_t colon_pos = token.find(':');
+  if (colon_pos != std::string::npos) {
+    token = token.substr(0, colon_pos);
+  }
+
+  NpuArgInfo info;
+  if (token[0] == '*') {
+    info.type = NpuArgType::POINTER;
+  } else if (token.substr(0, 3) == "i64" || token.substr(0, 3) == "u64") {
+    info.type = NpuArgType::I64;
+  } else if (token.substr(0, 3) == "i32" || token.substr(0, 3) == "u32") {
+    info.type = NpuArgType::I32;
+  } else if (token.substr(0, 4) == "fp64" || token.substr(0, 3) == "f64") {
+    info.type = NpuArgType::F64;
+  } else if (token.substr(0, 4) == "fp32" || token.substr(0, 3) == "f32") {
+    info.type = NpuArgType::F32;
+  } else if (token.substr(0, 4) == "fp16" || token.substr(0, 3) == "f16" ||
+             token.substr(0, 4) == "bf16") {
+    info.type = NpuArgType::F32;
+  } else {
+    LOG(WARNING) << "Unknown type in signature: " << token << ", defaulting to i64";
+    info.type = NpuArgType::I64;
+  }
+  layout.push_back(info);
+}
+
+inline std::vector<NpuArgInfo> parse_signature(const std::string& sig) {
+  std::vector<NpuArgInfo> layout;
+  for (std::string token : split_signature_tokens(sig)) {
+    append_signature_token(std::move(token), layout);
+  }
   return layout;
 }
 

--- a/include/triton_jit/triton_jit_function.h
+++ b/include/triton_jit/triton_jit_function.h
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
@@ -102,6 +103,18 @@ struct StaticSignature {
   }
 };
 
+template <typename T>
+struct is_std_tuple : std::false_type {};
+
+template <typename... Ts>
+struct is_std_tuple<std::tuple<Ts...>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_runtime_tuple_element_v =
+    is_same_ignore_cvref<int, T>::value || is_same_ignore_cvref<unsigned int, T>::value ||
+    is_same_ignore_cvref<int64_t, T>::value || is_same_ignore_cvref<uint64_t, T>::value ||
+    is_same_ignore_cvref<float, T>::value || is_same_ignore_cvref<double, T>::value;
+
 struct ArgHandle {
   const StaticSignature& ssig;
   /* data pointer of Tensors;
@@ -123,9 +136,36 @@ struct ArgHandle {
       handle_optional(item);
     } else if constexpr (is_same_ignore_cvref<c10::Scalar, T>::value) {
       handle_scalar(item);
+    } else if constexpr (is_std_tuple<std::remove_cvref_t<T>>::value) {
+      handle_tuple(item);
     } else {
       handle_arg_plain(item);
     }
+  }
+
+  template <typename... Ts>
+  void handle_tuple(const std::tuple<Ts...>& item) {
+    static_assert(sizeof...(Ts) > 0, "Runtime tuple arguments must not be empty");
+    static_assert((is_runtime_tuple_element_v<Ts> && ...),
+                  "Runtime tuple arguments contain an unsupported scalar type");
+    TORCH_CHECK(this->ssig.at(idx) != ArgType::CONSTEXPR,
+                "Runtime tuple arguments cannot be constexpr");
+
+    std::string grouped_signature = "(";
+    bool first = true;
+    auto append_element = [&](const auto& element) {
+      if (!first) {
+        grouped_signature += ",";
+      }
+      first = false;
+      this->buf.push_arg(element);
+      grouped_signature += triton_type<std::remove_cvref_t<decltype(element)>>::name;
+    };
+    std::apply([&](const auto&... elements) { (append_element(elements), ...); }, item);
+    grouped_signature += ")";
+
+    signature.push_back(std::move(grouped_signature));
+    idx++;
   }
 
   template <typename T>

--- a/scripts/standalone_compile.py
+++ b/scripts/standalone_compile.py
@@ -148,6 +148,63 @@ def sig_to_npu_type(sig: str) -> dict:
                 return {"type": "i64"}
 
 
+def _bracket_aware_split(sig: str) -> List[str]:
+    """Split on top-level commas while preserving parenthesized tuple groups."""
+    parts = []
+    current = []
+    depth = 0
+
+    for ch in sig:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            if depth == 0:
+                raise ValueError(f"unmatched ')' in signature: {sig}")
+            depth -= 1
+
+        if ch == "," and depth == 0:
+            part = "".join(current).strip()
+            if not part:
+                raise ValueError(f"empty token in signature: {sig}")
+            parts.append(part)
+            current = []
+        else:
+            current.append(ch)
+
+    if depth != 0:
+        raise ValueError(f"unmatched '(' in signature: {sig}")
+
+    final = "".join(current).strip()
+    if final:
+        parts.append(final)
+    elif parts:
+        raise ValueError(f"empty token in signature: {sig}")
+    return parts
+
+
+def _parse_type_token(token: str):
+    """Convert a grouped tuple token into Triton's nested signature form."""
+    token = token.strip()
+    if token.startswith("(") and token.endswith(")"):
+        inner = token[1:-1].strip()
+        if not inner:
+            raise ValueError("runtime tuple signature must not be empty")
+        elements = _bracket_aware_split(inner)
+        if any("(" in element or ")" in element for element in elements):
+            raise ValueError("nested runtime tuple signatures are not supported")
+        return tuple(elements)
+    return token
+
+
+def _normalize_gcu_signature(value):
+    """Normalize GCU signatures without changing runtime tuple ABI widths."""
+    if isinstance(value, tuple):
+        if "fp64" in value:
+            raise ValueError("GCU runtime tuple arguments do not support fp64 elements")
+        return value
+    return "fp32" if value == "fp64" else value
+
+
 def generate_arg_layout(
     signature: List[str], constexpr_indices: List[int]
 ) -> List[dict]:
@@ -183,10 +240,12 @@ def generate_arg_layout(
         if sig_clean == "nullopt":
             continue  # Skip nullopt
 
-        # Convert to NPU type
-        type_info = sig_to_npu_type(sig)
-        if type_info["type"] != "constexpr":
-            arg_layout.append(type_info)
+        parsed = _parse_type_token(sig)
+        runtime_types = parsed if isinstance(parsed, tuple) else (parsed,)
+        for runtime_type in runtime_types:
+            type_info = sig_to_npu_type(runtime_type)
+            if type_info["type"] != "constexpr":
+                arg_layout.append(type_info)
 
     return arg_layout
 
@@ -296,7 +355,7 @@ def _compile_a_kernel(
     # for bool use i1, for boolean values, use 0 or 1.
     # split it
 
-    signature: List[str] = list(map(lambda s: s.strip(" "), signature.split(",")))
+    signature: List[str] = _bracket_aware_split(signature)
     num_args = len(signature)
     assert num_args == len(
         fn.params
@@ -311,7 +370,9 @@ def _compile_a_kernel(
 
     # signature, no specializations here
     signature_without_spec = {
-        i: s.split(":")[0] for i, s in enumerate(signature) if i not in constants
+        i: _parse_type_token(s.split(":")[0])
+        for i, s in enumerate(signature)
+        if i not in constants
     }
 
     # specialization: divisibility by 16 or equal to 1
@@ -364,8 +425,7 @@ def _compile_a_kernel(
     # (GCU hardware/compiler does not support double precision operations)
     if get_backend() == "GCU":
         for k in signature_without_spec:
-            if signature_without_spec[k] == "fp64":
-                signature_without_spec[k] = "fp32"
+            signature_without_spec[k] = _normalize_gcu_signature(signature_without_spec[k])
 
     if Version("3.0.0") <= triton_version < Version("3.2.0"):
         src = triton.compiler.ASTSource(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,17 @@
 add_executable(test_launch_hooks test_launch_hooks.cpp)
 target_link_libraries(test_launch_hooks PRIVATE TritonJIT::triton_jit)
 add_test(NAME launch_hooks COMMAND test_launch_hooks)
+
+add_executable(test_tuple_args test_tuple_args.cpp)
+target_link_libraries(test_tuple_args PRIVATE TritonJIT::triton_jit)
+
+add_test(NAME tuple_args_cpp COMMAND test_tuple_args)
+add_test(
+    NAME tuple_signature_python
+    COMMAND
+        ${CMAKE_COMMAND} -E env
+        TRITON_JIT_BACKEND=${TRITON_BACKEND_NAME}
+        ${Python_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_standalone_tuple_signature.py
+        ${PROJECT_SOURCE_DIR}/scripts/standalone_compile.py
+)

--- a/tests/test_standalone_tuple_signature.py
+++ b/tests/test_standalone_tuple_signature.py
@@ -1,0 +1,67 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import importlib.util
+import sys
+
+
+def load_module(path):
+    spec = importlib.util.spec_from_file_location("standalone_compile", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def expect_value_error(fn, value):
+    try:
+        fn(value)
+    except ValueError:
+        return
+    raise AssertionError(f"expected ValueError for {value!r}")
+
+
+def main():
+    module = load_module(sys.argv[1])
+
+    assert module._bracket_aware_split("*fp32:16,(fp32,i32),64") == [
+        "*fp32:16",
+        "(fp32,i32)",
+        "64",
+    ]
+    assert module._parse_type_token("(fp32,i32)") == ("fp32", "i32")
+
+    expect_value_error(module._bracket_aware_split, "*fp32,(fp32,i32")
+    expect_value_error(module._bracket_aware_split, "*fp32,fp32)")
+    expect_value_error(module._parse_type_token, "()")
+    expect_value_error(module._parse_type_token, "((fp32,i32),i64)")
+
+    assert module.generate_arg_layout(
+        ["*fp32:16", "(fp32,i32)", "64"], [2]
+    ) == [
+        {"type": "ptr", "dtype": "fp32"},
+        {"type": "fp32"},
+        {"type": "i32"},
+    ]
+    assert module._normalize_gcu_signature(("fp32", "i32")) == ("fp32", "i32")
+    expect_value_error(module._normalize_gcu_signature, ("fp64", "i32"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tuple_args.cpp
+++ b/tests/test_tuple_args.cpp
@@ -1,0 +1,111 @@
+// Copyright 2026 FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <tuple>
+
+#include "triton_jit/backends/npu_arg_buffer.h"
+#include "triton_jit/triton_jit_function.h"
+
+namespace {
+
+bool expect(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << '\n';
+  }
+  return condition;
+}
+
+}  // namespace
+
+int main() {
+  using namespace triton_jit;
+
+  static_assert(is_runtime_tuple_element_v<float>);
+  static_assert(is_runtime_tuple_element_v<int32_t>);
+  static_assert(!is_runtime_tuple_element_v<bool>);
+  static_assert(!is_runtime_tuple_element_v<int16_t>);
+  static_assert(!is_runtime_tuple_element_v<at::Tensor>);
+
+  StaticSignature static_signature{1, {ArgType::NON_CONSTEXPR}};
+  ParameterBuffer buffer;
+  c10::SmallVector<std::string> signature;
+  ArgHandle handler{static_signature, buffer, signature, 0};
+
+  handler.handle_arg(std::tuple<float, int32_t>{3.5F, 7});
+
+  bool ok = true;
+  ok &= expect(handler.idx == 1, "tuple must consume one static-signature slot");
+  ok &= expect(buffer.size() == 2, "tuple must push one ABI value per element");
+  ok &= expect(signature.size() == 1, "tuple must emit one grouped signature token");
+  if (signature.size() == 1) {
+    ok &= expect(signature[0] == "(fp32,i32)", "grouped token must preserve element types");
+  }
+
+  auto pointers = buffer.get_ptrs();
+  if (pointers.size() == 2) {
+    ok &= expect(*reinterpret_cast<float*>(pointers[0]) == 3.5F,
+                 "first ABI value must be preserved");
+    ok &= expect(*reinterpret_cast<int32_t*>(pointers[1]) == 7,
+                 "second ABI value must be preserved");
+  }
+
+  const auto layout = parse_signature("*fp32:16,(fp32,i32),64");
+  ok &= expect(layout.size() == 3, "NPU layout must flatten the tuple into two ABI entries");
+  if (layout.size() == 3) {
+    ok &= expect(layout[0].type == NpuArgType::POINTER, "NPU layout entry 0 must be a pointer");
+    ok &= expect(layout[1].type == NpuArgType::F32, "NPU layout entry 1 must be fp32");
+    ok &= expect(layout[2].type == NpuArgType::I32, "NPU layout entry 2 must be i32");
+  }
+
+  StaticSignature constexpr_signature{1, {ArgType::CONSTEXPR}};
+  ParameterBuffer constexpr_buffer;
+  c10::SmallVector<std::string> constexpr_tokens;
+  ArgHandle constexpr_handler{constexpr_signature, constexpr_buffer, constexpr_tokens, 0};
+  bool constexpr_rejected = false;
+  try {
+    constexpr_handler.handle_arg(std::tuple<float, int32_t>{1.0F, 2});
+  } catch (const std::exception&) {
+    constexpr_rejected = true;
+  }
+  ok &= expect(constexpr_rejected, "runtime tuple must be rejected for a constexpr slot");
+  ok &= expect(constexpr_buffer.size() == 0, "rejected constexpr tuple must not push ABI values");
+
+  bool nested_signature_rejected = false;
+  try {
+    (void)parse_signature("((fp32,i32),i64)");
+  } catch (const std::invalid_argument&) {
+    nested_signature_rejected = true;
+  }
+  ok &= expect(nested_signature_rejected, "nested raw tuple signatures must be rejected");
+
+  bool malformed_signature_rejected = false;
+  try {
+    (void)parse_signature("(fp32(i32)i64)");
+  } catch (const std::invalid_argument&) {
+    malformed_signature_rejected = true;
+  }
+  ok &= expect(malformed_signature_rejected,
+               "tuple signatures with embedded parentheses must be rejected");
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## What

  Add runtime support for flat `std::tuple` arguments in the C++ JIT API.

  A tuple occupies one function-parameter slot and one grouped signature token, while its elements are expanded into multiple kernel ABI values:

  ```text
  std::tuple<float, int32_t>
  → (fp32,i32)
  → two runtime ABI arguments
  ```
  The Python bridge now performs bracket-aware signature parsing and restores grouped tokens as Triton tuple types. The NPU argument parser also expands tuple signatures into backend
  ABI layouts.

  Invalid or unsafe cases, including empty or nested tuples, unsupported element types, constexpr tuples, and GCU tuples containing fp64, are rejected explicitly.

  ## Why

  The previous runtime assumed a one-to-one mapping between function parameters, signature tokens, and ABI values. Tuple arguments require a 1:1:N mapping and were incorrectly split
  on their internal commas.

  This change keeps the function signature aligned with Triton parameters while passing every tuple element to the device kernel in source order.

  ## Testing

  Validated on Cambricon MLU590:

  - Full Release build passed.
  - CTest passed: 3/3, including the existing launch-hook test.
  - Two-element tuple cases: 4/4 passed.
  - Four-element mixed-type tuple cases: 2/2 passed.
  - 10,000/10,000 warm-cache launches passed.
  - Full MLU operator regression: 23/23 passed.
  - Grouped tuple tokens were preserved in cache keys.

  ## Compatibility

  Existing Tensor, scalar, optional, constexpr, and non-tuple call paths are unchanged.