### PR TITLE
fix: resolve kernel script dir under Debian multiarch install layout

### DIFF
--- a/src/jit_utils.cpp
+++ b/src/jit_utils.cpp
@@ -47,16 +47,26 @@ std::filesystem::path get_path_of_this_library() {
 
 std::filesystem::path get_script_dir() {
   const static std::filesystem::path script_dir = []() {
-    std::filesystem::path installed_script_dir =
-        get_path_of_this_library().parent_path().parent_path() / "share" / "triton_jit" / "scripts";
-
-    if (std::filesystem::exists(installed_script_dir)) {
-      return installed_script_dir;
-    } else {
-      std::filesystem::path source_script_dir =
-          std::filesystem::path(__FILE__).parent_path().parent_path() / "scripts";
-      return source_script_dir;
+    // Explicit override wins, so a user can always point at the scripts.
+    if (const char* env = std::getenv("TRITON_JIT_SCRIPT_DIR")) {
+      return std::filesystem::path(env);
     }
+
+    // Search upward from the library directory for share/triton_jit/scripts.
+    // The library may live at <prefix>/lib/libtriton_jit.so, but under Debian
+    // multiarch it is at <prefix>/lib/x86_64-linux-gnu/libtriton_jit.so, one
+    // level deeper, so a fixed parent count does not work for both layouts.
+    std::filesystem::path dir = get_path_of_this_library().parent_path();
+    for (int i = 0; i < 3 && !dir.empty(); ++i) {
+      std::filesystem::path candidate = dir / "share" / "triton_jit" / "scripts";
+      if (std::filesystem::exists(candidate)) {
+        return candidate;
+      }
+      dir = dir.parent_path();
+    }
+
+    // Fall back to the in-tree scripts (source checkout / build tree).
+    return std::filesystem::path(__FILE__).parent_path().parent_path() / "scripts";
   }();
   return script_dir;
 }


### PR DESCRIPTION
## Problem

`get_script_dir()` locates the bundled kernel scripts (`gen_ssig.py`,
`standalone_compile.py`) relative to the shared library:

```cpp
get_path_of_this_library().parent_path().parent_path() / "share" / "triton_jit" / "scripts";
```

This assumes the library is at `<prefix>/lib/libtriton_jit.so`, so two `parent_path()`
calls reach `<prefix>` and then `/share`. But under Debian/Ubuntu **multiarch**, the
library installs one level deeper — `<prefix>/lib/x86_64-linux-gnu/libtriton_jit.so` —
so the two-level walk lands on `<prefix>/lib/share/...`, which does not exist. The
scripts are at `<prefix>/share/triton_jit/scripts`.

That deeper path is exactly the layout the Debian packaging ships (`debian/*.install`
uses `usr/lib/*/libtriton_jit.so`). So an **installed** runtime package aborts on the
first JIT call:

```
terminate called after throwing an instance of 'pybind11::error_already_set'
  what():  ModuleNotFoundError: No module named 'gen_ssig'
```

The `__FILE__`-based source fallback does not exist on an installed system, and there
was no environment override, so there is no clean workaround for a packaged install.

## Reproduction

Found while validating the `libtriton-jit-nvidia` Debian package on Ubuntu 22.04 /
A100. The `-dev` package builds and links fine, the `.so` loads, the embedded
interpreter starts — and then the first `TritonJITFunction` call aborts as above,
because `/usr/lib/share/triton_jit/scripts` is computed while the scripts live in
`/usr/share/triton_jit/scripts`.

## Fix

Walk up from the library directory looking for `share/triton_jit/scripts` (covers both
the plain `<prefix>/lib` and the multiarch `<prefix>/lib/<triplet>` layouts), and honor
a `TRITON_JIT_SCRIPT_DIR` override for anything unusual. The source-tree fallback is
kept for in-tree/build-tree use.

After this change the same packaged install runs a downstream Triton kernel end to end
(`find_package(TritonJIT)` → link `TritonJIT::triton_jit` → JIT compile → execute on
GPU) with no symlink workaround.

## Suggestion

A post-install smoke that actually *runs* one JIT kernel (not just load/link) would
catch this class of defect; install + link checks alone pass right up to the abort.