### PR TITLE
feat(runtime): support JITFunction arguments

### DIFF
--- a/include/triton_jit/backends/npu_arg_buffer.h
+++ b/include/triton_jit/backends/npu_arg_buffer.h
@@ -204,6 +204,10 @@ inline void append_signature_token(std::string token, std::vector<NpuArgInfo>& l
     return;
   }
 
+  if (token.starts_with("@jit:")) {
+    return;
+  }
+
   if (token == "nullopt" || token == "true" || token == "false") {
     return;
   }

--- a/include/triton_jit/jit_function_arg.h
+++ b/include/triton_jit/jit_function_arg.h
@@ -1,0 +1,46 @@
+// Copyright 2026 FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <string>
+
+namespace triton_jit {
+
+// A compile-time reference to a Triton JITFunction defined in a Python module.
+//
+// Construction snapshots the module path and exact source contents. Recreate
+// this object after intentionally changing the source file.
+class JitFunctionArg {
+ public:
+  JitFunctionArg(std::string module_path, std::string function_name);
+
+  const std::string& module_path() const noexcept;
+  const std::string& function_name() const noexcept;
+  const std::string& source_fingerprint() const noexcept;
+  std::string signature_token() const;
+
+ private:
+  std::string module_path_;
+  std::string function_name_;
+  std::string source_fingerprint_;
+};
+
+}  // namespace triton_jit

--- a/include/triton_jit/triton_jit_function.h
+++ b/include/triton_jit/triton_jit_function.h
@@ -35,6 +35,7 @@
 #include "fmt/core.h"
 #include "triton_jit/backend_config.h"
 #include "triton_jit/backend_policy.h"
+#include "triton_jit/jit_function_arg.h"
 #include "triton_jit/jit_utils.h"
 #include "triton_jit/triton_kernel.h"
 
@@ -136,11 +137,19 @@ struct ArgHandle {
       handle_optional(item);
     } else if constexpr (is_same_ignore_cvref<c10::Scalar, T>::value) {
       handle_scalar(item);
+    } else if constexpr (is_same_ignore_cvref<JitFunctionArg, T>::value) {
+      handle_jitfunction(item);
     } else if constexpr (is_std_tuple<std::remove_cvref_t<T>>::value) {
       handle_tuple(item);
     } else {
       handle_arg_plain(item);
     }
+  }
+
+  void handle_jitfunction(const JitFunctionArg& item) {
+    (void)this->ssig.at(idx);
+    signature.push_back(item.signature_token());
+    idx++;
   }
 
   template <typename... Ts>

--- a/scripts/standalone_compile.py
+++ b/scripts/standalone_compile.py
@@ -19,8 +19,13 @@
 # SOFTWARE.
 
 import importlib.util
+import io
 import json
+import linecache
 import os
+import re
+import sys
+import tokenize
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import List, Tuple, Union
@@ -205,6 +210,109 @@ def _normalize_gcu_signature(value):
     return "fp32" if value == "fp64" else value
 
 
+def _fnv1a64(data: bytes) -> str:
+    """Return a stable, lowercase FNV-1a 64 fingerprint."""
+    value = 14695981039346656037
+    for byte in data:
+        value ^= byte
+        value = (value * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return f"{value:016x}"
+
+
+def _decode_jitfunction_field(value: str, field_name: str) -> str:
+    if not value or len(value) % 2 or re.fullmatch(r"[0-9a-fA-F]+", value) is None:
+        raise ValueError(f"invalid hex-encoded JITFunction {field_name}")
+    try:
+        decoded = bytes.fromhex(value).decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"JITFunction {field_name} is not valid UTF-8") from error
+    if not decoded:
+        raise ValueError(f"JITFunction {field_name} must not be empty")
+    return decoded
+
+
+def _parse_jitfunction_token(token: str) -> Tuple[str, str, str]:
+    """Parse @jit:<hex-path>:<hex-name>:<source-fingerprint>."""
+    fields = token.split(":")
+    if len(fields) != 4 or fields[0] != "@jit":
+        raise ValueError(f"invalid JITFunction token: {token}")
+
+    path = _decode_jitfunction_field(fields[1], "module path")
+    name = _decode_jitfunction_field(fields[2], "function name")
+    fingerprint = fields[3]
+    if re.fullmatch(r"[0-9a-f]{16}", fingerprint) is None:
+        raise ValueError("JITFunction fingerprint must be 16 lowercase hex characters")
+    if not Path(path).is_absolute():
+        raise ValueError("JITFunction module path must be absolute")
+    return path, name, fingerprint
+
+
+def _unwrap_jitfunction(value, description: str):
+    seen = set()
+    current = value
+    for _ in range(32):
+        if isinstance(current, triton.runtime.JITFunction):
+            return current
+        identity = id(current)
+        if identity in seen:
+            raise TypeError(f"cycle while unwrapping {description}")
+        seen.add(identity)
+        if not hasattr(current, "fn"):
+            raise TypeError(f"{description} does not resolve to a Triton JITFunction")
+        current = current.fn
+    raise TypeError(f"wrapper depth exceeded while unwrapping {description}")
+
+
+def _load_jitfunction(path: str, name: str, fingerprint: str):
+    """Validate a source snapshot and resolve one Triton JITFunction."""
+    source_path = Path(path)
+    source = source_path.read_bytes()
+    actual_fingerprint = _fnv1a64(source)
+    if actual_fingerprint != fingerprint:
+        raise ValueError(
+            "JITFunction source changed after the C++ argument was constructed: "
+            f"expected {fingerprint}, got {actual_fingerprint}"
+        )
+
+    module_name = (
+        f"_triton_jit_callee_{fingerprint}_{_fnv1a64(str(source_path).encode('utf-8'))}"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, source_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load JITFunction module: {source_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        # Execute the exact bytes whose fingerprint was validated above.
+        # SourceFileLoader may otherwise reuse a same-timestamp, same-size .pyc
+        # after an in-place source edit, disconnecting the cache key from code.
+        encoding, _ = tokenize.detect_encoding(io.BytesIO(source).readline)
+        source_text = source.decode(encoding)
+        linecache.cache[str(source_path)] = (
+            len(source),
+            None,
+            source_text.splitlines(keepends=True),
+            str(source_path),
+        )
+        code = compile(source, str(source_path), "exec")
+        exec(code, module.__dict__)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+
+    value = getattr(module, name)
+    return _unwrap_jitfunction(value, f"{source_path}:{name}")
+
+
+def _resolve_jitfunction_constants(signature: List[str]) -> dict:
+    resolved = {}
+    for index, token in enumerate(signature):
+        if token.startswith("@jit:"):
+            path, name, fingerprint = _parse_jitfunction_token(token)
+            resolved[index] = _load_jitfunction(path, name, fingerprint)
+    return resolved
+
+
 def generate_arg_layout(
     signature: List[str], constexpr_indices: List[int]
 ) -> List[dict]:
@@ -221,7 +329,7 @@ def generate_arg_layout(
 
     for i, sig in enumerate(signature):
         # Check if this is a constexpr by index or by value
-        if i in constexpr_indices:
+        if i in constexpr_indices or sig.startswith("@jit:"):
             continue
 
         # Try to parse as constexpr value
@@ -361,12 +469,15 @@ def _compile_a_kernel(
         fn.params
     ), f"number of argument mismatch:  Actual({num_args}), Function Definition({len(fn.params)})"
 
-    constants = {
-        i: constexpr(s) for i, s in enumerate(signature) if i in constexpr_indices
-    }
-    assert len(constants) == len(
-        constexpr_indices
-    ), f"number of constexpr mismatch:  Actual({len(constants)}), Function Definition({len(constexpr_indices)})"
+    constants = _resolve_jitfunction_constants(signature)
+    for i, token in enumerate(signature):
+        if i in constexpr_indices and i not in constants:
+            constants[i] = constexpr(token)
+    missing_constexpr = [i for i in constexpr_indices if i not in constants]
+    assert not missing_constexpr, (
+        "number of constexpr mismatch: "
+        f"missing parameter indices {missing_constexpr}"
+    )
 
     # signature, no specializations here
     signature_without_spec = {
@@ -376,7 +487,11 @@ def _compile_a_kernel(
     }
 
     # specialization: divisibility by 16 or equal to 1
-    hints = {i: constexpr(s.split(":")[1]) for i, s in enumerate(signature) if ":" in s}
+    hints = {
+        i: constexpr(s.rsplit(":", 1)[1])
+        for i, s in enumerate(signature)
+        if i not in constants and ":" in s
+    }
     hints = {k: v for k, v in hints.items() if v is not None}
     for h in hints.values():
         assert h in [1, 16], f"Only 1 and 16 are valid hints, got {h}"

--- a/scripts/standalone_compile.py
+++ b/scripts/standalone_compile.py
@@ -281,6 +281,10 @@ def _load_jitfunction(path: str, name: str, fingerprint: str):
     if spec is None or spec.loader is None:
         raise ImportError(f"cannot load JITFunction module: {source_path}")
     module = importlib.util.module_from_spec(spec)
+    linecache_key = str(source_path)
+    missing = object()
+    previous_module = sys.modules.get(module_name, missing)
+    previous_linecache = linecache.cache.get(linecache_key, missing)
     sys.modules[module_name] = module
     try:
         # Execute the exact bytes whose fingerprint was validated above.
@@ -288,20 +292,26 @@ def _load_jitfunction(path: str, name: str, fingerprint: str):
         # after an in-place source edit, disconnecting the cache key from code.
         encoding, _ = tokenize.detect_encoding(io.BytesIO(source).readline)
         source_text = source.decode(encoding)
-        linecache.cache[str(source_path)] = (
+        linecache.cache[linecache_key] = (
             len(source),
             None,
             source_text.splitlines(keepends=True),
-            str(source_path),
+            linecache_key,
         )
-        code = compile(source, str(source_path), "exec")
+        code = compile(source, linecache_key, "exec")
         exec(code, module.__dict__)
+        value = getattr(module, name)
+        return _unwrap_jitfunction(value, f"{source_path}:{name}")
     except Exception:
-        sys.modules.pop(module_name, None)
+        if previous_module is missing:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous_module
+        if previous_linecache is missing:
+            linecache.cache.pop(linecache_key, None)
+        else:
+            linecache.cache[linecache_key] = previous_linecache
         raise
-
-    value = getattr(module, name)
-    return _unwrap_jitfunction(value, f"{source_path}:{name}")
 
 
 def _resolve_jitfunction_constants(signature: List[str]) -> dict:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,13 @@
 # the cxx flags from torch, so we just merge then as one target, for simplicity
 # then it can use the same cxx flags with public dependency transitivity
 # --------------------------- triton jit function ---------------------------
-add_library(triton_jit SHARED triton_jit_function.cpp jit_utils.cpp kernel_metadata.cpp launch_hooks.cpp)
+add_library(
+  triton_jit SHARED
+  triton_jit_function.cpp
+  jit_function_arg.cpp
+  jit_utils.cpp
+  kernel_metadata.cpp
+  launch_hooks.cpp)
 target_include_directories(triton_jit
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/src/jit_function_arg.cpp
+++ b/src/jit_function_arg.cpp
@@ -1,0 +1,118 @@
+// Copyright 2026 FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "triton_jit/jit_function_arg.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iterator>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+#include "fmt/core.h"
+
+namespace triton_jit {
+namespace {
+
+uint64_t fnv1a64(std::string_view bytes) {
+  uint64_t hash = 14695981039346656037ULL;
+  for (const unsigned char byte : bytes) {
+    hash ^= byte;
+    hash *= 1099511628211ULL;
+  }
+  return hash;
+}
+
+std::string hex_encode(std::string_view bytes) {
+  static constexpr char kHexDigits[] = "0123456789abcdef";
+  std::string encoded;
+  encoded.reserve(bytes.size() * 2);
+  for (const unsigned char byte : bytes) {
+    encoded.push_back(kHexDigits[byte >> 4]);
+    encoded.push_back(kHexDigits[byte & 0x0f]);
+  }
+  return encoded;
+}
+
+std::string hex_u64(uint64_t value) {
+  std::ostringstream output;
+  output << std::hex << std::setfill('0') << std::setw(16) << value;
+  return output.str();
+}
+
+std::string read_module_source(const std::filesystem::path& path) {
+  std::ifstream input{path, std::ios::binary};
+  if (!input) {
+    throw std::runtime_error(fmt::format("Failed to open JITFunction module: {}", path.string()));
+  }
+  return {std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}};
+}
+
+}  // namespace
+
+JitFunctionArg::JitFunctionArg(std::string module_path, std::string function_name)
+    : function_name_(std::move(function_name)) {
+  if (module_path.empty()) {
+    throw std::invalid_argument("JITFunction module path must not be empty");
+  }
+  if (function_name_.empty()) {
+    throw std::invalid_argument("JITFunction name must not be empty");
+  }
+
+  std::error_code error;
+  auto path = std::filesystem::absolute(std::filesystem::path{module_path}, error);
+  if (error) {
+    throw std::invalid_argument(
+        fmt::format("Invalid JITFunction module path '{}': {}", module_path, error.message()));
+  }
+  path = path.lexically_normal();
+  if (!std::filesystem::is_regular_file(path, error) || error) {
+    throw std::invalid_argument(
+        fmt::format("JITFunction module is not a regular file: {}", path.string()));
+  }
+
+  module_path_ = path.string();
+  source_fingerprint_ = hex_u64(fnv1a64(read_module_source(path)));
+}
+
+const std::string& JitFunctionArg::module_path() const noexcept {
+  return module_path_;
+}
+
+const std::string& JitFunctionArg::function_name() const noexcept {
+  return function_name_;
+}
+
+const std::string& JitFunctionArg::source_fingerprint() const noexcept {
+  return source_fingerprint_;
+}
+
+std::string JitFunctionArg::signature_token() const {
+  return fmt::format("@jit:{}:{}:{}", hex_encode(module_path_), hex_encode(function_name_),
+                     source_fingerprint_);
+}
+
+}  // namespace triton_jit

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,4 +32,5 @@ add_test(
         ${CMAKE_CURRENT_SOURCE_DIR}/test_standalone_jit_function.py
         ${PROJECT_SOURCE_DIR}/scripts/standalone_compile.py
         ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/jit_function_module.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/jit_function_compile_module.py
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,3 +15,21 @@ add_test(
         ${CMAKE_CURRENT_SOURCE_DIR}/test_standalone_tuple_signature.py
         ${PROJECT_SOURCE_DIR}/scripts/standalone_compile.py
 )
+
+add_executable(test_jit_function_arg test_jit_function_arg.cpp)
+target_link_libraries(test_jit_function_arg PRIVATE TritonJIT::triton_jit)
+target_compile_definitions(
+    test_jit_function_arg
+    PRIVATE TRITON_JIT_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+)
+add_test(NAME jit_function_arg_cpp COMMAND test_jit_function_arg)
+add_test(
+    NAME jit_function_arg_python
+    COMMAND
+        ${CMAKE_COMMAND} -E env
+        TRITON_JIT_BACKEND=${TRITON_BACKEND_NAME}
+        ${Python_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_standalone_jit_function.py
+        ${PROJECT_SOURCE_DIR}/scripts/standalone_compile.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/jit_function_module.py
+)

--- a/tests/fixtures/jit_function_compile_module.py
+++ b/tests/fixtures/jit_function_compile_module.py
@@ -1,0 +1,19 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def mul_func(x, y):
+    return x * y
+
+
+@triton.jit
+def apply_jitfunction_kernel(
+    output,
+    operation: tl.constexpr,
+    n_elements: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    offsets = tl.arange(0, block_size)
+    values = operation(offsets.to(tl.float32), 2.0)
+    tl.store(output + offsets, values, mask=offsets < n_elements)

--- a/tests/fixtures/jit_function_module.py
+++ b/tests/fixtures/jit_function_module.py
@@ -1,0 +1,10 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def mul_func(x, y):
+    return x * y
+
+
+not_a_jit_function = 7

--- a/tests/test_jit_function_arg.cpp
+++ b/tests/test_jit_function_arg.cpp
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <random>
 #include <stdexcept>
 #include <string>
 
@@ -43,6 +44,44 @@ bool is_lower_hex(std::string_view value) {
          std::all_of(value.begin(), value.end(),
                      [](char ch) { return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'); });
 }
+
+class TemporaryDirectory {
+ public:
+  TemporaryDirectory() {
+    const auto base = std::filesystem::temp_directory_path();
+    std::random_device random;
+    for (int attempt = 0; attempt < 128; ++attempt) {
+      auto candidate =
+          base / ("libtriton_jit_function_arg_test-" + std::to_string(random()) + "-" +
+                  std::to_string(random()));
+      std::error_code error;
+      if (std::filesystem::create_directory(candidate, error)) {
+        path_ = std::move(candidate);
+        return;
+      }
+      if (error && error != std::errc::file_exists) {
+        throw std::filesystem::filesystem_error(
+            "Failed to create temporary test directory", candidate, error);
+      }
+    }
+    throw std::runtime_error("Failed to create a unique temporary test directory");
+  }
+
+  ~TemporaryDirectory() {
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
+  }
+
+  TemporaryDirectory(const TemporaryDirectory&) = delete;
+  TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
+
+  const std::filesystem::path& path() const noexcept {
+    return path_;
+  }
+
+ private:
+  std::filesystem::path path_;
+};
 
 template <typename Exception, typename Fn>
 bool expect_throws(Fn&& fn, const char* message) {
@@ -108,8 +147,8 @@ int main() {
                  "NPU layout must preserve the following runtime argument");
   }
 
-  const auto temporary =
-      std::filesystem::temp_directory_path() / "libtriton_jit_function_arg_test.py";
+  TemporaryDirectory temporary_directory;
+  const auto temporary = temporary_directory.path() / "module.py";
   {
     std::ofstream output{temporary, std::ios::binary | std::ios::trunc};
     output << "value = 1\n";
@@ -122,7 +161,6 @@ int main() {
     output << "value = 2\n";
   }
   JitFunctionArg second_snapshot{temporary.string(), "mul_func"};
-  std::filesystem::remove(temporary);
   ok &= expect(first_snapshot.signature_token() != second_snapshot.signature_token(),
                "changed source must produce a different token");
 

--- a/tests/test_jit_function_arg.cpp
+++ b/tests/test_jit_function_arg.cpp
@@ -1,0 +1,137 @@
+// Copyright 2026 FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "triton_jit/backends/npu_arg_buffer.h"
+#include "triton_jit/jit_function_arg.h"
+#include "triton_jit/triton_jit_function.h"
+
+namespace {
+
+bool expect(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << '\n';
+  }
+  return condition;
+}
+
+bool is_lower_hex(std::string_view value) {
+  return !value.empty() &&
+         std::all_of(value.begin(), value.end(),
+                     [](char ch) { return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'); });
+}
+
+template <typename Exception, typename Fn>
+bool expect_throws(Fn&& fn, const char* message) {
+  try {
+    fn();
+  } catch (const Exception&) {
+    return true;
+  } catch (...) {
+  }
+  std::cerr << "FAIL: " << message << '\n';
+  return false;
+}
+
+}  // namespace
+
+int main() {
+  using namespace triton_jit;
+
+  const auto fixture =
+      std::filesystem::path{TRITON_JIT_TEST_SOURCE_DIR} / "fixtures/jit_function_module.py";
+  JitFunctionArg function{fixture.string(), "mul_func"};
+  JitFunctionArg same_function{fixture.string(), "mul_func"};
+
+  StaticSignature static_signature{1, {ArgType::NON_CONSTEXPR}};
+  ParameterBuffer buffer;
+  c10::SmallVector<std::string> signature;
+  ArgHandle handler{static_signature, buffer, signature, 0};
+  handler.handle_arg(function);
+
+  bool ok = true;
+  ok &= expect(handler.idx == 1, "JITFunction must consume one static-signature slot");
+  ok &= expect(buffer.size() == 0, "JITFunction must not push an ABI value");
+  ok &= expect(signature.size() == 1, "JITFunction must emit one signature token");
+  if (signature.size() == 1) {
+    const auto& token = signature[0];
+    ok &= expect(token.starts_with("@jit:"), "JITFunction token must use @jit prefix");
+    ok &= expect(token.find(',') == std::string::npos,
+                 "JITFunction token must be comma-safe");
+    const auto path_end = token.find(':', 5);
+    const auto name_end =
+        path_end == std::string::npos ? std::string::npos : token.find(':', path_end + 1);
+    ok &= expect(path_end != std::string::npos && name_end != std::string::npos &&
+                     token.find(':', name_end + 1) == std::string::npos,
+                 "JITFunction token must have exactly four colon-separated fields");
+    if (path_end != std::string::npos && name_end != std::string::npos) {
+      ok &= expect(is_lower_hex(std::string_view{token}.substr(5, path_end - 5)),
+                   "module path must be lowercase hex");
+      ok &= expect(is_lower_hex(
+                       std::string_view{token}.substr(path_end + 1, name_end - path_end - 1)),
+                   "function name must be lowercase hex");
+      const auto fingerprint = std::string_view{token}.substr(name_end + 1);
+      ok &= expect(fingerprint.size() == 16 && is_lower_hex(fingerprint),
+                   "source fingerprint must be 16 lowercase hex characters");
+    }
+  }
+  ok &= expect(function.signature_token() == same_function.signature_token(),
+               "unchanged source must produce a deterministic token");
+  const auto npu_layout = parse_signature(function.signature_token() + ",*fp32");
+  ok &= expect(npu_layout.size() == 1,
+               "NPU layout must not allocate an ABI entry for JITFunction");
+  if (npu_layout.size() == 1) {
+    ok &= expect(npu_layout[0].type == NpuArgType::POINTER,
+                 "NPU layout must preserve the following runtime argument");
+  }
+
+  const auto temporary =
+      std::filesystem::temp_directory_path() / "libtriton_jit_function_arg_test.py";
+  {
+    std::ofstream output{temporary, std::ios::binary | std::ios::trunc};
+    output << "value = 1\n";
+  }
+  JitFunctionArg first_snapshot{temporary.string(), "mul_func"};
+  ok &= expect(first_snapshot.source_fingerprint() == "e37bb3a25227347c",
+               "FNV-1a fingerprint must match the known value");
+  {
+    std::ofstream output{temporary, std::ios::binary | std::ios::trunc};
+    output << "value = 2\n";
+  }
+  JitFunctionArg second_snapshot{temporary.string(), "mul_func"};
+  std::filesystem::remove(temporary);
+  ok &= expect(first_snapshot.signature_token() != second_snapshot.signature_token(),
+               "changed source must produce a different token");
+
+  ok &= expect_throws<std::invalid_argument>(
+      [&] { (void)JitFunctionArg{fixture.string(), ""}; },
+      "an empty function name must be rejected");
+  ok &= expect_throws<std::invalid_argument>(
+      [&] { (void)JitFunctionArg{"/definitely/missing/jit_function.py", "mul_func"}; },
+      "a missing module must be rejected");
+
+  return ok ? 0 : 1;
+}

--- a/tests/test_standalone_jit_function.py
+++ b/tests/test_standalone_jit_function.py
@@ -19,6 +19,8 @@
 # SOFTWARE.
 
 import importlib.util
+import linecache
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -47,6 +49,35 @@ def make_token(module, source_path, function_name):
         f"@jit:{str(source_path.resolve()).encode().hex()}:"
         f"{function_name.encode().hex()}:{module._fnv1a64(source)}"
     )
+
+
+def module_name_for(module, source_path, fingerprint):
+    return (
+        f"_triton_jit_callee_{fingerprint}_"
+        f"{module._fnv1a64(str(source_path).encode('utf-8'))}"
+    )
+
+
+def expect_failed_load_restores_registries(
+    module, source_path, function_name, fingerprint, exception_type
+):
+    module_name = module_name_for(module, source_path, fingerprint)
+    linecache_key = str(source_path)
+    missing = object()
+    previous_module = sys.modules.get(module_name, missing)
+    previous_linecache = linecache.cache.get(linecache_key, missing)
+
+    expect_exception(
+        exception_type,
+        lambda: module._load_jitfunction(
+            str(source_path), function_name, fingerprint
+        ),
+    )
+
+    restored_module = sys.modules.get(module_name, missing)
+    restored_linecache = linecache.cache.get(linecache_key, missing)
+    assert restored_module is previous_module
+    assert restored_linecache is previous_linecache
 
 
 def main():
@@ -87,13 +118,19 @@ def main():
         ValueError,
         lambda: module._load_jitfunction(path, name, "0000000000000000"),
     )
-    expect_exception(
+    expect_failed_load_restores_registries(
+        module,
+        fixture,
+        "missing_function",
+        fingerprint,
         AttributeError,
-        lambda: module._load_jitfunction(path, "missing_function", fingerprint),
     )
-    expect_exception(
+    expect_failed_load_restores_registries(
+        module,
+        fixture,
+        "not_a_jit_function",
+        fingerprint,
         TypeError,
-        lambda: module._load_jitfunction(path, "not_a_jit_function", fingerprint),
     )
 
     with tempfile.TemporaryDirectory() as directory:
@@ -129,12 +166,42 @@ def main():
             encoding="utf-8",
         )
         cycle_fingerprint = module._fnv1a64(cycle_path.read_bytes())
-        expect_exception(
+        expect_failed_load_restores_registries(
+            module,
+            cycle_path,
+            "cycle",
+            cycle_fingerprint,
             TypeError,
-            lambda: module._load_jitfunction(
-                str(cycle_path), "cycle", cycle_fingerprint
-            ),
         )
+
+        broken_path = Path(directory) / "broken.py"
+        broken_path.write_text(
+            "raise RuntimeError('module execution failed')\n",
+            encoding="utf-8",
+        )
+        broken_fingerprint = module._fnv1a64(broken_path.read_bytes())
+        expect_failed_load_restores_registries(
+            module,
+            broken_path,
+            "operation",
+            broken_fingerprint,
+            RuntimeError,
+        )
+
+    if os.environ.get("TRITON_JIT_TEST_COMPILE") == "1":
+        compile_fixture = Path(sys.argv[3]).resolve()
+        compile_module = load_module(compile_fixture)
+        compile_token = make_token(module, compile_fixture, "mul_func")
+        cache_dir = Path(
+            module._compile_a_kernel(
+                compile_module.apply_jitfunction_kernel,
+                f"*fp32,{compile_token},32,32",
+                num_warps=1,
+                num_stages=1,
+            )
+        )
+        assert cache_dir.is_dir()
+        assert any(cache_dir.iterdir())
 
 
 if __name__ == "__main__":

--- a/tests/test_standalone_jit_function.py
+++ b/tests/test_standalone_jit_function.py
@@ -1,0 +1,141 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+import triton
+
+
+def load_module(path):
+    spec = importlib.util.spec_from_file_location("standalone_compile_jit_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def expect_exception(exception_type, fn):
+    try:
+        fn()
+    except exception_type:
+        return
+    raise AssertionError(f"expected {exception_type.__name__}")
+
+
+def make_token(module, source_path, function_name):
+    source = source_path.read_bytes()
+    return (
+        f"@jit:{str(source_path.resolve()).encode().hex()}:"
+        f"{function_name.encode().hex()}:{module._fnv1a64(source)}"
+    )
+
+
+def main():
+    module = load_module(sys.argv[1])
+    fixture = Path(sys.argv[2]).resolve()
+    token = make_token(module, fixture, "mul_func")
+    path, name, fingerprint = module._parse_jitfunction_token(token)
+
+    assert path == str(fixture)
+    assert name == "mul_func"
+    assert fingerprint == module._fnv1a64(fixture.read_bytes())
+    assert isinstance(
+        module._load_jitfunction(path, name, fingerprint),
+        triton.runtime.JITFunction,
+    )
+    resolved = module._resolve_jitfunction_constants([token, "*fp32"])
+    assert list(resolved) == [0]
+    assert isinstance(resolved[0], triton.runtime.JITFunction)
+    assert module.generate_arg_layout([token, "*fp32", "i32"], []) == [
+        {"type": "ptr", "dtype": "fp32"},
+        {"type": "i32"},
+    ]
+
+    invalid_tokens = [
+        "jit:00:00:0000000000000000",
+        "@jit:00:00",
+        "@jit:0:61:0000000000000000",
+        "@jit:zz:61:0000000000000000",
+        "@jit::61:0000000000000000",
+        "@jit:2f746d70::0000000000000000",
+        "@jit:2f746d70:61:1234",
+        "@jit:2f746d70:61:gggggggggggggggg",
+    ]
+    for invalid in invalid_tokens:
+        expect_exception(ValueError, lambda value=invalid: module._parse_jitfunction_token(value))
+
+    expect_exception(
+        ValueError,
+        lambda: module._load_jitfunction(path, name, "0000000000000000"),
+    )
+    expect_exception(
+        AttributeError,
+        lambda: module._load_jitfunction(path, "missing_function", fingerprint),
+    )
+    expect_exception(
+        TypeError,
+        lambda: module._load_jitfunction(path, "not_a_jit_function", fingerprint),
+    )
+
+    with tempfile.TemporaryDirectory() as directory:
+        mutable_path = Path(directory) / "mutable.py"
+        first_source = (
+            "import triton\n"
+            "import triton.language as tl\n"
+            "@triton.jit\n"
+            "def operation(x, y):\n"
+            "    return x * y\n"
+        )
+        second_source = first_source.replace("x * y", "x + y")
+        assert len(first_source) == len(second_source)
+        mutable_path.write_text(first_source, encoding="utf-8")
+        first_fingerprint = module._fnv1a64(mutable_path.read_bytes())
+        first_function = module._load_jitfunction(
+            str(mutable_path), "operation", first_fingerprint
+        )
+        mutable_path.write_text(second_source, encoding="utf-8")
+        second_fingerprint = module._fnv1a64(mutable_path.read_bytes())
+        second_function = module._load_jitfunction(
+            str(mutable_path), "operation", second_fingerprint
+        )
+        assert first_fingerprint != second_fingerprint
+        assert first_function.src != second_function.src
+
+        cycle_path = Path(directory) / "cycle.py"
+        cycle_path.write_text(
+            "class Wrapper:\n"
+            "    pass\n"
+            "cycle = Wrapper()\n"
+            "cycle.fn = cycle\n",
+            encoding="utf-8",
+        )
+        cycle_fingerprint = module._fnv1a64(cycle_path.read_bytes())
+        expect_exception(
+            TypeError,
+            lambda: module._load_jitfunction(
+                str(cycle_path), "cycle", cycle_fingerprint
+            ),
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

  Add JITFunctionArg support to the C++ runtime. JITFunction references are encoded as compile-time signature tokens, restored by the Python bridge, and injected into triton.compile
  without entering the kernel ABI.

  The implementation also validates source fingerprints, cleans up failed module loads, avoids temporary-file races, and keeps NPU argument parsing aligned.