### PR TITLE
fix: narrow integer types by value range in handle_specialized, matching Triton runtime behavior

### DIFF
--- a/include/triton_jit/jit_utils.h
+++ b/include/triton_jit/jit_utils.h
@@ -208,7 +208,7 @@ struct triton_type : triton_type_helper<std::remove_cv_t<std::remove_reference_t
 
 // Mimic Triton runtime's native_specialize_impl: narrow integer types by value range
 template <typename T>
-constexpr const char* integer_type_name(const T& v) {
+constexpr const char* narrow_type_name(const T& v) {
   if constexpr (std::is_integral_v<std::decay_t<T>>) {
     if constexpr (std::is_unsigned_v<std::decay_t<T>>) {
       return triton_type<T>::name;

--- a/include/triton_jit/jit_utils.h
+++ b/include/triton_jit/jit_utils.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <map>
@@ -204,6 +205,21 @@ DEFINE_TRITON_TYPE(std::string, "constexpr");
 
 template <typename T>
 struct triton_type : triton_type_helper<std::remove_cv_t<std::remove_reference_t<T>>> {};
+
+// Mimic Triton runtime's native_specialize_impl: narrow integer types by value range
+template <typename T>
+constexpr const char* integer_type_name(const T& v) {
+  if constexpr (std::is_integral_v<std::decay_t<T>>) {
+    if constexpr (std::is_unsigned_v<std::decay_t<T>>) {
+      return triton_type<T>::name;
+    }
+    if (v >= INT32_MIN && v <= INT32_MAX) {
+      return "i32";
+    }
+    return "i64";
+  }
+  return triton_type<T>::name;
+}
 
 // path of python executable
 std::filesystem::path get_script_dir();

--- a/include/triton_jit/triton_jit_function.h
+++ b/include/triton_jit/triton_jit_function.h
@@ -258,7 +258,7 @@ struct ArgHandle {
 
   template <typename T>
   void handle_specialized(const T& item) {
-    const char* dtype = integer_type_name(item);
+    const char* dtype = narrow_type_name(item);
     if constexpr (std::is_integral_v<std::remove_cv_t<std::remove_reference_t<decltype(item)>>>) {
       const char* specialization = "";
 #if defined(BACKEND_NPU)
@@ -281,7 +281,7 @@ struct ArgHandle {
 
   template <typename T>
   void handle_specialized_no_alignment(const T& item) {
-    const char* dtype = integer_type_name(item);
+    const char* dtype = narrow_type_name(item);
     if constexpr (std::is_integral_v<std::remove_cv_t<std::remove_reference_t<decltype(item)>>>) {
       const bool equal_to_1 = item == 1;
 #if defined(BACKEND_NPU)
@@ -302,7 +302,7 @@ struct ArgHandle {
   template <typename T>
   void handle_non_constexpr(const T& item) {
     this->buf.push_arg(item);
-    const char* dtype = integer_type_name(item);
+    const char* dtype = narrow_type_name(item);
     signature.push_back(dtype);
   }
 

--- a/include/triton_jit/triton_jit_function.h
+++ b/include/triton_jit/triton_jit_function.h
@@ -258,7 +258,7 @@ struct ArgHandle {
 
   template <typename T>
   void handle_specialized(const T& item) {
-    const char* dtype = triton_type<decltype(item)>::name;
+    const char* dtype = integer_type_name(item);
     if constexpr (std::is_integral_v<std::remove_cv_t<std::remove_reference_t<decltype(item)>>>) {
       const char* specialization = "";
 #if defined(BACKEND_NPU)
@@ -281,7 +281,7 @@ struct ArgHandle {
 
   template <typename T>
   void handle_specialized_no_alignment(const T& item) {
-    const char* dtype = triton_type<decltype(item)>::name;
+    const char* dtype = integer_type_name(item);
     if constexpr (std::is_integral_v<std::remove_cv_t<std::remove_reference_t<decltype(item)>>>) {
       const bool equal_to_1 = item == 1;
 #if defined(BACKEND_NPU)
@@ -302,7 +302,7 @@ struct ArgHandle {
   template <typename T>
   void handle_non_constexpr(const T& item) {
     this->buf.push_arg(item);
-    const char* dtype = triton_type<decltype(item)>::name;
+    const char* dtype = integer_type_name(item);
     signature.push_back(dtype);
   }
 


### PR DESCRIPTION
### Description

`handle_specialized`, `handle_specialized_no_alignment`, and `handle_non_constexpr` previously used the C++ declared type to determine the Triton type name. Triton runtime performs value-range narrowing on integers: values that fit in int32 become `i32`, and only values outside that range become `i64`. When a parameter value of 1 triggers `:1` specialization, it gets elevated to a compile-time constant with type int32. If another parameter in the same kernel retains `i64` (from the C++ declared type), the Triton compiler raises a `Mismatched type` error across if/elif/else branches. 

### Changes

**jit_utils.h** — Add `integer_type_name()`, which narrows signed integer types by value range: `[INT32_MIN, INT32_MAX]` maps to `"i32"`, otherwise `"i64"`. 

**triton_jit_function.h** — Three call sites (`handle_specialized`, `handle_specialized_no_alignment`, `handle_non_constexpr`) replace `triton_type<decltype(item)>::name` with `integer_type_name(item)`.