### PR TITLE
perf: eliminate per-launch CPU overhead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,9 @@ endif()
 # ==============================================================================
 # --- nlohmann_json ---
 if(TRITON_JIT_USE_EXTERNAL_JSON)
-    find_package(nlohmann_json 3.11.3 REQUIRED)
+    # Only basic APIs (parse/value/contains/get) are used, so any
+    # nlohmann_json >= 3.10.5 works (the version shipped by Ubuntu 22.04).
+    find_package(nlohmann_json 3.10.5 REQUIRED)
 else()
     github_url(JSON_URL "nlohmann/json/releases/download/v3.11.3/json.tar.xz")
     FetchContent_Declare(json URL ${JSON_URL} DOWNLOAD_EXTRACT_TIMESTAMP ON)

--- a/include/triton_jit/backends/cuda_backend.h
+++ b/include/triton_jit/backends/cuda_backend.h
@@ -78,8 +78,6 @@ struct CudaBackend {
                             unsigned block_z,
                             void** args,
                             const LaunchOptions& opts) {
-    LOG(INFO) << "cuLaunchKernel";
-
     CUresult result = cuLaunchKernel(kernel,
                                      grid_x,
                                      grid_y,

--- a/include/triton_jit/triton_jit_function.h
+++ b/include/triton_jit/triton_jit_function.h
@@ -432,19 +432,61 @@ class TritonJITFunctionImpl {
                             unsigned int grid_z,
                             unsigned int num_warps,
                             unsigned int num_stages,
-                            std::string full_signature,
+                            const std::string& full_signature,
                             void** args,
                             size_t num_args = 0) const {
+    // Cache the kernel pointer to amortise get_kernel() lookup on this hot path.
+    // Compile options and the active device are part of the cache identity.
+    // launch_with_raw_args is the hot path; avoid fmt::format + map lookup.
+    using KernelPtr = const TritonKernelImpl<Backend>*;
+    struct CacheEntry {
+      std::string full_signature;
+      unsigned int num_warps = 0;
+      unsigned int num_stages = 0;
+      int device_index = -1;
+      KernelPtr kernel = nullptr;
+    };
+    thread_local static std::unordered_map<const TritonJITFunctionImpl*, CacheEntry> tl_cache;
+
     Backend::ensure_context();
     int device_index = Backend::get_device_index();
+    auto& entry = tl_cache[this];
+    KernelPtr cached_kernel = nullptr;
+    if (entry.kernel != nullptr && entry.full_signature == full_signature &&
+        entry.num_warps == num_warps && entry.num_stages == num_stages &&
+        entry.device_index == device_index) {
+      cached_kernel = entry.kernel;
+    }
 
+    if (cached_kernel == nullptr) {
+      CompileOptions copts;
+      copts.num_warps = static_cast<int>(num_warps);
+      copts.num_stages = static_cast<int>(num_stages);
+      const TritonKernelImpl<Backend>& kernel =
+          this->get_kernel(full_signature, copts, device_index);
+      cached_kernel = &kernel;
+      entry.full_signature = full_signature;
+      entry.num_warps = num_warps;
+      entry.num_stages = num_stages;
+      entry.device_index = device_index;
+      entry.kernel = cached_kernel;
+    }
+
+    cached_kernel->launch_with_signature(
+        grid_x, grid_y, grid_z, num_warps, stream, args, full_signature, num_args);
+  }
+
+  /// Pre-compile the kernel without launching.
+  /// Useful during plan creation to ensure first exec does not trigger Python compilation.
+  void compile(const std::string& full_signature,
+               unsigned int num_warps,
+               unsigned int num_stages,
+               int device_index) const {
+    Backend::ensure_context();
     CompileOptions copts;
     copts.num_warps = static_cast<int>(num_warps);
     copts.num_stages = static_cast<int>(num_stages);
-    const TritonKernelImpl<Backend>& kernel =
-        this->get_kernel(full_signature, copts, device_index);
-
-    kernel.launch_with_signature(grid_x, grid_y, grid_z, num_warps, stream, args, full_signature, num_args);
+    this->get_kernel(full_signature, copts, device_index);
   }
 
  private:

--- a/include/triton_jit/triton_kernel.h
+++ b/include/triton_jit/triton_kernel.h
@@ -86,6 +86,7 @@ class TritonKernelImpl {
   std::string dir_;
   std::string kernel_name_;
   mutable bool loaded_ = false;
+  mutable unsigned int cached_shared_memory_ = 0;
   mutable typename Backend::KernelHandle kernel_handle_;
 
  public:
@@ -136,8 +137,7 @@ class TritonKernelImpl {
     unsigned int block_y = 1;
     unsigned int block_z = 1;
 
-    // Get shared memory size from backend
-    unsigned int shared_memory = Backend::get_shared_memory(dir_, kernel_name_);
+    const unsigned int shared_memory = cached_shared_memory_;
 
     // Prepare backend-specific launch options (no branching)
     auto opts = Backend::prepare_launch(dir_, kernel_name_, shared_memory, signature, num_args);
@@ -200,6 +200,7 @@ class TritonKernelImpl {
 
     // Note: For thread safety, the backend's load_kernel should be thread-safe
     kernel_handle_ = Backend::load_kernel(dir_, kernel_name_);
+    cached_shared_memory_ = Backend::get_shared_memory(dir_, kernel_name_);
     loaded_ = true;
   }
 

--- a/tests/test_launch_hooks.cpp
+++ b/tests/test_launch_hooks.cpp
@@ -55,6 +55,7 @@ struct FakeBackend {
 
   static constexpr unsigned int WARP_SIZE = 32;
   inline static std::atomic<int> launch_count {0};
+  inline static std::atomic<int> shared_memory_query_count {0};
   inline static std::atomic<bool> throw_on_launch {false};
 
   static void launch_kernel(StreamType,
@@ -85,6 +86,7 @@ struct FakeBackend {
   }
 
   static unsigned int get_shared_memory(const std::string&, const std::string&) {
+    ++shared_memory_query_count;
     return 128;
   }
 
@@ -98,6 +100,7 @@ struct FakeBackend {
 
   static void reset() {
     launch_count = 0;
+    shared_memory_query_count = 0;
     throw_on_launch = false;
   }
 };
@@ -182,6 +185,7 @@ void test_reentrant_clear_keeps_current_snapshot() {
   REQUIRE(enter_count == 1);
   REQUIRE(exit_count == 1);
   REQUIRE(FakeBackend::launch_count == 2);
+  REQUIRE(FakeBackend::shared_memory_query_count == 1);
 }
 
 void test_enter_exception_prevents_launch() {


### PR DESCRIPTION
## Summary

- remove per-launch CUDA logging and cache the raw-argument kernel lookup by
  function, signature, compile options, and active device
- cache shared-memory metadata after the kernel is loaded instead of querying
  it for every launch
- retain the precompile API used by FlagFFT while preserving the current
  `CompileOptions` and launch-hook behavior on `master`
- allow external nlohmann-json >= 3.10.5 so distro packages such as openEuler
  24.03's 3.11.2 can be used with FetchContent fully disconnected

The nlohmann-json version-floor commit overlaps the CMake portion of #48.
That PR targets the older `multi-backend` packaging branch; this branch is
based on current `master`, where the change is required by the FlagFFT
submodule build.

## Verification

Built in `openeuler/cuda:13.0.0-oe2403lts` with GCC 12.3, CUDA 13.0,
system `fmt-devel` 8.1.1, system `nlohmann-json-devel` 3.11.2, and
`FETCHCONTENT_FULLY_DISCONNECTED=ON`.

```text
Found nlohmann_json 3.11.2 (minimum required 3.10.5)
1/1 Test #1: launch_hooks ... Passed
100% tests passed, 0 tests failed out of 1
```
