### PR TITLE
fix: relax nlohmann_json version requirement to 3.10.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,9 @@ endif()
 # ==============================================================================
 # --- nlohmann_json ---
 if(TRITON_JIT_USE_EXTERNAL_JSON)
-    find_package(nlohmann_json 3.11.3 REQUIRED)
+    # Only basic APIs (parse/value/contains/get) are used, so any
+    # nlohmann_json >= 3.10.5 works (the version shipped by Ubuntu 22.04).
+    find_package(nlohmann_json 3.10.5 REQUIRED)
 else()
     github_url(JSON_URL "nlohmann/json/releases/download/v3.11.3/json.tar.xz")
     FetchContent_Declare(json URL ${JSON_URL} DOWNLOAD_EXTRACT_TIMESTAMP ON)


### PR DESCRIPTION
## Summary

Only basic nlohmann_json APIs are used (parse / value / contains / get), so any version >= 3.10.5 works — which is exactly what Ubuntu 22.04 ships. The current `find_package(nlohmann_json 3.11.3 REQUIRED)` forces downstream packagers to either FetchContent the tarball or pull a newer system package for no functional reason.

This is the same change FlagFFT's packaging branch carries (it builds against system nlohmann-json3-dev on Ubuntu 22.04); extracted here as a standalone fix so it can land independently.

Split out of #62 — see that PR's close note for the rationale (the core perf optimization there duplicates #22).