### PR TITLE
feat(runtime): support raw device pointers in typed launches

### DIFF
--- a/include/triton_jit/device_ptr.h
+++ b/include/triton_jit/device_ptr.h
@@ -1,0 +1,233 @@
+// Copyright 2026 FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+// Device pointer arguments for callers that do not hold an at::Tensor.
+//
+// The typed launch path derives a pointer argument's signature token from the
+// tensor it is given: the address supplies the alignment hint and the tensor
+// supplies the element dtype. A C or C++ caller holding a raw device address
+// (CUdeviceptr, CNaddr, void*) has no tensor to pass, and the address alone
+// does not carry an element type.
+//
+// TritonDevicePtr closes that gap by pairing the address with an explicit
+// dtype. It is accepted wherever an at::Tensor is, and yields the same
+// signature token, the same specialization and the same compilation cache
+// entry as the equivalent tensor argument.
+//
+// This header intentionally has no torch dependency, so tooling that only
+// needs the dtype vocabulary can include it on its own.
+
+namespace triton_jit {
+
+/// Element types a device pointer may address, spelled as in Triton's
+/// signature grammar (see to_triton_typename). The fp8 entries have no C++
+/// scalar counterpart and are therefore only reachable through the
+/// runtime-dtype overload of device_ptr.
+enum class TritonDType : int8_t {
+  kI1 = 0,
+  kI8,
+  kI16,
+  kI32,
+  kI64,
+  kU8,
+  kU16,
+  kU32,
+  kU64,
+  kFp16,
+  kBf16,
+  kFp32,
+  kFp64,
+  kFp8E4NV,
+  kFp8E5,
+};
+
+/**
+ * @brief Spell a dtype tag as Triton spells it in a kernel signature.
+ */
+constexpr const char* to_triton_typename(TritonDType t) {
+  switch (t) {
+    case TritonDType::kI1:
+      return "i1";
+    case TritonDType::kI8:
+      return "i8";
+    case TritonDType::kI16:
+      return "i16";
+    case TritonDType::kI32:
+      return "i32";
+    case TritonDType::kI64:
+      return "i64";
+    case TritonDType::kU8:
+      return "u8";
+    case TritonDType::kU16:
+      return "u16";
+    case TritonDType::kU32:
+      return "u32";
+    case TritonDType::kU64:
+      return "u64";
+    case TritonDType::kFp16:
+      return "fp16";
+    case TritonDType::kBf16:
+      return "bf16";
+    case TritonDType::kFp32:
+      return "fp32";
+    case TritonDType::kFp64:
+      return "fp64";
+    case TritonDType::kFp8E4NV:
+      return "fp8e4nv";
+    case TritonDType::kFp8E5:
+      return "fp8e5";
+  }
+  return "<unsupported_dtype>";
+}
+
+/// A device address together with the element type stored at it. Trivially
+/// copyable, and packed into the runtime argument buffer as the eight bytes of
+/// `value`, which is the ABI a void* or CUdeviceptr argument already uses.
+struct TritonDevicePtr {
+  std::uintptr_t value;
+  TritonDType dtype;
+};
+
+/// Maps a C++ element type to its dtype tag, so that device_ptr can deduce
+/// the tag from a typed pointer.
+///
+/// Types without a mapping are rejected at compile time rather than guessed
+/// at. A library with its own storage types registers them by specializing
+/// this trait, after which its pointers deduce like any built-in type:
+///
+///     template <>
+///     struct triton_jit::triton_dtype_of<MyHalf> {
+///       static constexpr TritonDType value = TritonDType::kFp16;
+///     };
+template <typename T, typename Enable = void>
+struct triton_dtype_of {
+  static_assert(sizeof(T) == 0,
+                "no TritonDType mapping for this element type; "
+                "use device_ptr(p, TritonDType) or specialize triton_dtype_of");
+};
+
+template <typename T>
+struct triton_dtype_of<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
+ private:
+  static constexpr TritonDType compute() {
+    if constexpr (std::is_same_v<T, bool>) {
+      return TritonDType::kI1;
+    } else if constexpr (std::is_same_v<T, float>) {
+      return TritonDType::kFp32;
+    } else if constexpr (std::is_same_v<T, double>) {
+      return TritonDType::kFp64;
+    } else if constexpr (std::is_integral_v<T> && std::is_signed_v<T>) {
+      // Dispatch on width rather than on type identity: long and long long
+      // are distinct types of the same width, and both must map.
+      static_assert(sizeof(T) <= 8, "integer element type wider than 64 bits");
+      return sizeof(T) == 1   ? TritonDType::kI8
+             : sizeof(T) == 2 ? TritonDType::kI16
+             : sizeof(T) == 4 ? TritonDType::kI32
+                              : TritonDType::kI64;
+    } else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
+      static_assert(sizeof(T) <= 8, "integer element type wider than 64 bits");
+      return sizeof(T) == 1   ? TritonDType::kU8
+             : sizeof(T) == 2 ? TritonDType::kU16
+             : sizeof(T) == 4 ? TritonDType::kU32
+                              : TritonDType::kU64;
+    } else {
+      static_assert(sizeof(T) == 0,
+                    "no TritonDType mapping for this arithmetic type "
+                    "(long double is not supported)");
+    }
+  }
+
+ public:
+  static constexpr TritonDType value = compute();
+};
+
+// device_ptr overloads
+// -------------------------------------------------------------------------
+// Four ways to name a device pointer, covering how callers come by one: a
+// typed pointer, a typed pointer read as another element type, an integer
+// device handle, and an element type only known at run time. Overload
+// resolution separates them by argument form, so all four share one name.
+
+/**
+ * @brief Wrap a typed device pointer, deducing its element type.
+ *
+ * @code
+ * triton_jit::device_ptr(arguments.A);   // float* -> *fp32
+ * @endcode
+ */
+template <typename T, typename = decltype(triton_dtype_of<std::remove_cv_t<T>>::value)>
+inline TritonDevicePtr device_ptr(T* p) {
+  return TritonDevicePtr {reinterpret_cast<std::uintptr_t>(p), triton_dtype_of<std::remove_cv_t<T>>::value};
+}
+
+/**
+ * @brief Wrap a device pointer under a different element type than it is
+ *        declared with, for buffers the kernel reads through another view --
+ *        an interleaved complex buffer addressed as pairs of fp32, say.
+ *
+ * @code
+ * triton_jit::device_ptr<float>(arguments.x);   // Complex* -> *fp32
+ * @endcode
+ */
+template <typename Elem,
+          typename T,
+          typename = std::enable_if_t<!std::is_same_v<std::remove_cv_t<Elem>, std::remove_cv_t<T>>>>
+inline TritonDevicePtr device_ptr(T* p) {
+  return TritonDevicePtr {reinterpret_cast<std::uintptr_t>(p),
+                          triton_dtype_of<std::remove_cv_t<Elem>>::value};
+}
+
+/**
+ * @brief Wrap an integer device handle, such as a CUdeviceptr. The element
+ *        type must be given: an integer address carries none.
+ *
+ * @code
+ * triton_jit::device_ptr<float>(cu_device_ptr);
+ * @endcode
+ */
+template <typename Elem>
+inline TritonDevicePtr device_ptr(std::uintptr_t raw) {
+  return TritonDevicePtr {raw, triton_dtype_of<std::remove_cv_t<Elem>>::value};
+}
+
+/**
+ * @brief Wrap a device pointer whose element type is chosen at run time, as
+ *        when a C API takes the type as a parameter. This is also the only
+ *        way to name the fp8 types, which have no C++ counterpart.
+ *
+ * @code
+ * triton_jit::device_ptr(arguments.A, to_dtype(arguments.Atype));
+ * @endcode
+ */
+inline TritonDevicePtr device_ptr(const void* p, TritonDType dtype) {
+  return TritonDevicePtr {reinterpret_cast<std::uintptr_t>(p), dtype};
+}
+
+/// @overload
+inline TritonDevicePtr device_ptr(std::uintptr_t raw, TritonDType dtype) {
+  return TritonDevicePtr {raw, dtype};
+}
+
+}  // namespace triton_jit

--- a/include/triton_jit/jit_utils.h
+++ b/include/triton_jit/jit_utils.h
@@ -148,6 +148,14 @@ constexpr const char* spec(T v) {
   return v % 16 == 0 ? ":16" : v == 1 ? ":1" : "";
 }
 
+// Alignment specialization for device addresses. Pointers only ever get the
+// divisibility hint: an address that happened to equal 1 must not become ":1",
+// which would drop the pointer from the runtime ABI like a constant integer.
+template <typename T>
+constexpr const char* ptr_spec(T v) {
+  return v % 16 == 0 ? ":16" : "";
+}
+
 template <typename T, typename = void>
 struct has_data_ptr : std::false_type {};
 

--- a/include/triton_jit/triton_jit_function.h
+++ b/include/triton_jit/triton_jit_function.h
@@ -35,6 +35,7 @@
 #include "fmt/core.h"
 #include "triton_jit/backend_config.h"
 #include "triton_jit/backend_policy.h"
+#include "triton_jit/device_ptr.h"
 #include "triton_jit/jit_function_arg.h"
 #include "triton_jit/jit_utils.h"
 #include "triton_jit/triton_kernel.h"
@@ -213,6 +214,8 @@ struct ArgHandle {
   void handle_arg_plain(const T& item) {
     if constexpr (is_same_ignore_cvref<at::Tensor, T>::value) {
       handle_tensor(item);
+    } else if constexpr (is_same_ignore_cvref<TritonDevicePtr, T>::value) {
+      handle_device_ptr(item);
     } else if constexpr (is_same_ignore_cvref<std::nullopt_t, T>::value) {
       // Assumption: nullopt is always treated as constexpr,
       // even if the parameter is not marked as constexpr
@@ -251,9 +254,30 @@ struct ArgHandle {
     const char* specialization = "";
     if (ssig.at(idx) == ArgType::SPECIALIZED) {
 #if defined(BACKEND_NPU)
-      // NPU: disable :1 specialization to keep arg list consistent
+      // NPU: disable pointer specialization to keep arg list consistent
 #else
-      specialization = spec(reinterpret_cast<std::uintptr_t>(p_item));
+      specialization = ptr_spec(reinterpret_cast<std::uintptr_t>(p_item));
+#endif
+    }
+    std::string sig_for_idx = fmt::format("*{}{}", dtype, specialization);
+    signature.push_back(sig_for_idx);
+  }
+
+  // Raw device pointer with an explicit element dtype (see device_ptr.h).
+  // Mirrors handle_tensor: pushed into the runtime ABI verbatim, specialized
+  // only on 16-byte address alignment.
+  void handle_device_ptr(const TritonDevicePtr& item) {
+    // Assumption: a device pointer is never constexpr
+    TORCH_CHECK(this->ssig.at(idx) != ArgType::CONSTEXPR);
+    this->buf.push_arg(item.value);
+    const char* dtype = to_triton_typename(item.dtype);
+
+    const char* specialization = "";
+    if (ssig.at(idx) == ArgType::SPECIALIZED) {
+#if defined(BACKEND_NPU)
+      // NPU: disable pointer specialization to keep arg list consistent
+#else
+      specialization = ptr_spec(item.value);
 #endif
     }
     std::string sig_for_idx = fmt::format("*{}{}", dtype, specialization);

--- a/scripts/standalone_compile.py
+++ b/scripts/standalone_compile.py
@@ -540,6 +540,16 @@ def _compile_a_kernel(
     # integer 1 in value, but the corresponding ArgType in static signature is not constexpr are added into constants
     for i in equal_to_1:
         constants.update({i: 1})
+        # An equal-to-one argument is a compile-time constant, so it must also
+        # leave the runtime signature. `signature_without_spec` was built before
+        # these indices joined `constants`, and the >=3.3 branch below prefers it,
+        # so without this the same parameter is declared twice: as "i32" in the
+        # signature and as the constant 1. Triton still folds it -- the generated
+        # code is identical -- but the resulting ASTSource, and therefore the
+        # compilation cache key, no longer matches the one the native Python
+        # runtime builds for the same call, so the two paths never share a
+        # compiled kernel.
+        signature_without_spec.pop(i, None)
         # Nones in value, but the corresponding ArgType in static signature is not constexpr are added into constants
     for i, v in signature_without_spec.items():
         if v == "nullopt":

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,3 +34,18 @@ add_test(
         ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/jit_function_module.py
         ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/jit_function_compile_module.py
 )
+
+add_executable(test_device_ptr test_device_ptr.cpp)
+target_link_libraries(test_device_ptr PRIVATE TritonJIT::triton_jit)
+add_test(NAME device_ptr_cpp COMMAND test_device_ptr)
+
+add_test(
+    NAME standalone_equal_to_one
+    COMMAND
+        ${CMAKE_COMMAND} -E env
+        TRITON_JIT_BACKEND=${TRITON_BACKEND_NAME}
+        ${Python_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_standalone_equal_to_one.py
+        ${PROJECT_SOURCE_DIR}/scripts/standalone_compile.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/equal_to_one_module.py
+)

--- a/tests/fixtures/equal_to_one_module.py
+++ b/tests/fixtures/equal_to_one_module.py
@@ -1,0 +1,31 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Kernel with one strided access, used to check equal-to-one handling."""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def strided_copy_kernel(out_ptr, stride, size, BLOCK: tl.constexpr):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < size
+    tl.store(out_ptr + offsets * stride, offsets, mask=mask)

--- a/tests/test_device_ptr.cpp
+++ b/tests/test_device_ptr.cpp
@@ -1,0 +1,251 @@
+// Copyright 2026 FlagOS Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Signature and runtime-ABI behavior of TritonDevicePtr, checked against the
+// production ArgHandle. The static signature is built by hand so the test needs
+// neither a device nor the Python bridge.
+
+#include <cstdint>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "triton_jit/triton_jit_function.h"
+
+namespace {
+
+int g_failures = 0;
+
+bool expect(bool condition, const char* message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << '\n';
+    ++g_failures;
+  }
+  return condition;
+}
+
+struct Emitted {
+  std::vector<std::string> signature;
+  size_t abi_args;
+  int consumed;
+};
+
+// Run one argument list through ArgHandle with the given per-argument kinds.
+template <typename... Args>
+Emitted emit(const std::vector<triton_jit::ArgType>& kinds, Args... args) {
+  using namespace triton_jit;
+  StaticSignature static_signature {static_cast<int>(kinds.size()), kinds};
+  ParameterBuffer buffer;
+  c10::SmallVector<std::string> signature;
+  ArgHandle handler {static_signature, buffer, signature, 0};
+  handler.handle_args(args...);
+  return Emitted {std::vector<std::string>(signature.begin(), signature.end()), buffer.size(), handler.idx};
+}
+
+void expect_token(const Emitted& e, size_t index, const char* expected, const char* what) {
+  if (!expect(e.signature.size() > index, what)) {
+    return;
+  }
+  if (e.signature[index] != expected) {
+    std::cerr << "FAIL: " << what << " (got \"" << e.signature[index] << "\", expected \"" << expected
+              << "\")\n";
+    ++g_failures;
+  }
+}
+
+// Addresses are never dereferenced; only their alignment matters here.
+constexpr std::uintptr_t kAligned = 0x7F0000001000ULL;     // 16-byte aligned
+constexpr std::uintptr_t kMisaligned = 0x7F0000001004ULL;  // 4 bytes off
+constexpr std::uintptr_t kAddressOne = 1ULL;               // must never fold to ":1"
+
+struct Interleaved {
+  float re;
+  float im;
+};
+
+struct StorageHalf {
+  std::uint16_t bits;
+};
+
+}  // namespace
+
+// A downstream library maps its own storage type onto a Triton dtype.
+template <>
+struct triton_jit::triton_dtype_of<StorageHalf> {
+  static constexpr triton_jit::TritonDType value = triton_jit::TritonDType::kFp16;
+};
+
+int main() {
+  using namespace triton_jit;
+
+  // ---- dtype tags ---------------------------------------------------------
+  static_assert(std::is_trivially_copyable_v<TritonDevicePtr>);
+  static_assert(triton_dtype_of<float>::value == TritonDType::kFp32);
+  static_assert(triton_dtype_of<double>::value == TritonDType::kFp64);
+  static_assert(triton_dtype_of<bool>::value == TritonDType::kI1);
+  static_assert(triton_dtype_of<std::int32_t>::value == TritonDType::kI32);
+  static_assert(triton_dtype_of<std::uint64_t>::value == TritonDType::kU64);
+  // long and long long are distinct types of the same width; both must map.
+  static_assert(triton_dtype_of<long>::value == triton_dtype_of<long long>::value);
+  expect(std::string(to_triton_typename(TritonDType::kFp8E4NV)) == "fp8e4nv",
+         "fp8e4nv must round-trip through to_triton_typename");
+  expect(std::string(to_triton_typename(TritonDType::kBf16)) == "bf16",
+         "bf16 must round-trip through to_triton_typename");
+
+  // ---- factories ----------------------------------------------------------
+  {
+    float storage = 0.0F;
+    const double const_storage = 0.0;
+    Interleaved complex_storage {};
+    StorageHalf half_storage {};
+
+    expect(device_ptr(&storage).dtype == TritonDType::kFp32,
+           "pointee-deduced factory must map float* to fp32");
+    expect(device_ptr(&const_storage).dtype == TritonDType::kFp64,
+           "pointee-deduced factory must see through const");
+    expect(device_ptr<float>(&complex_storage).dtype == TritonDType::kFp32,
+           "explicit-element factory must reinterpret an interleaved buffer as fp32");
+    expect(device_ptr<float>(&storage).dtype == TritonDType::kFp32,
+           "explicit-element factory must also accept a matching pointee type");
+    expect(device_ptr(&half_storage).dtype == TritonDType::kFp16,
+           "a downstream triton_dtype_of specialization must be honored");
+
+    const TritonDevicePtr handle = device_ptr<float>(kAligned);
+    expect(handle.value == kAligned && handle.dtype == TritonDType::kFp32,
+           "integer-handle factory must preserve the address and element type");
+    const TritonDevicePtr runtime = device_ptr(&storage, TritonDType::kFp8E5);
+    expect(runtime.dtype == TritonDType::kFp8E5,
+           "runtime-dtype factory must accept a dtype chosen at run time");
+  }
+
+  // ---- pointer specialization --------------------------------------------
+  const std::vector<ArgType> one_specialized {ArgType::SPECIALIZED};
+#if defined(BACKEND_NPU)
+  // NPU keeps every argument in the ABI and emits no specialization hints, so
+  // the arg list stays consistent with the layout the launcher parses.
+  const char* const kAlignedPtr = "*fp32";
+  const char* const kAlignedI32 = "i32";
+  const char* const kEqualToOne = "i32";
+  const size_t kEqualToOneAbi = 1;
+#else
+  const char* const kAlignedPtr = "*fp32:16";
+  const char* const kAlignedI32 = "i32:16";
+  const char* const kEqualToOne = "i32:1";
+  const size_t kEqualToOneAbi = 0;
+#endif
+
+  {
+    const Emitted aligned = emit(one_specialized, device_ptr<float>(kAligned));
+    expect_token(aligned, 0, kAlignedPtr, "an aligned device pointer must carry the ':16' hint");
+    expect(aligned.abi_args == 1, "a device pointer always stays in the runtime ABI");
+    expect(aligned.consumed == 1, "a device pointer must consume one signature slot");
+
+    const Emitted misaligned = emit(one_specialized, device_ptr<float>(kMisaligned));
+    expect_token(misaligned, 0, "*fp32", "a misaligned device pointer must not claim ':16'");
+    expect(misaligned.abi_args == 1, "a misaligned device pointer stays in the runtime ABI");
+
+    // An address equal to 1 must not be mistaken for an equal-to-one integer:
+    // that would fold the pointer away and drop it from the runtime ABI.
+    const Emitted address_one = emit(one_specialized, device_ptr<float>(kAddressOne));
+    expect_token(address_one, 0, "*fp32", "a device pointer must never be specialized to ':1'");
+    expect(address_one.abi_args == 1, "a device pointer must never leave the runtime ABI");
+
+    const Emitted null_ptr = emit(one_specialized, device_ptr<float>(std::uintptr_t {0}));
+    expect_token(null_ptr, 0, kAlignedPtr, "a null device pointer is trivially aligned");
+  }
+
+  // ---- dtypes reach the signature ----------------------------------------
+  {
+    const Emitted half = emit(one_specialized, device_ptr(kAligned, TritonDType::kFp16));
+#if defined(BACKEND_NPU)
+    expect_token(half, 0, "*fp16", "a runtime dtype must reach the signature");
+#else
+    expect_token(half, 0, "*fp16:16", "a runtime dtype must reach the signature");
+#endif
+    const Emitted fp8 = emit(one_specialized, device_ptr(kAligned, TritonDType::kFp8E4NV));
+#if defined(BACKEND_NPU)
+    expect_token(fp8, 0, "*fp8e4nv", "fp8 has no C++ type and must come from the runtime dtype");
+#else
+    expect_token(fp8, 0, "*fp8e4nv:16", "fp8 has no C++ type and must come from the runtime dtype");
+#endif
+  }
+
+  // ---- other ArgType kinds ------------------------------------------------
+  {
+    const Emitted plain = emit({ArgType::NON_CONSTEXPR}, device_ptr<float>(kAligned));
+    expect_token(plain, 0, "*fp32", "a non-specialized device pointer must not carry an alignment hint");
+    expect(plain.abi_args == 1, "a non-specialized device pointer stays in the runtime ABI");
+
+    const Emitted no_alignment = emit({ArgType::SPECIALIZED_NO_ALIGNMENT}, device_ptr<float>(kAligned));
+    expect_token(no_alignment, 0, "*fp32", "do_not_specialize_on_alignment must suppress the ':16' hint");
+    expect(no_alignment.abi_args == 1, "do_not_specialize_on_alignment keeps the pointer in the runtime ABI");
+  }
+
+  // ---- optional device pointers ------------------------------------------
+  {
+    const Emitted present =
+        emit(one_specialized, std::optional<TritonDevicePtr> {device_ptr<float>(kAligned)});
+    expect_token(present, 0, kAlignedPtr, "an engaged optional behaves like a plain pointer");
+    expect(present.abi_args == 1, "an engaged optional stays in the runtime ABI");
+
+    const Emitted absent = emit(one_specialized, std::optional<TritonDevicePtr> {});
+    expect_token(absent, 0, "nullopt", "a disengaged optional must become a constexpr None");
+    expect(absent.abi_args == 0, "a disengaged optional must not enter the runtime ABI");
+  }
+
+  // ---- a full argument list, mixing pointers with the existing kinds ------
+  {
+    // (a, x, y, alpha, m, incx, BLOCK) -- the shape of a C BLAS level-2 launch.
+    const std::vector<ArgType> kinds {
+        ArgType::SPECIALIZED,    // a
+        ArgType::SPECIALIZED,    // x
+        ArgType::SPECIALIZED,    // y
+        ArgType::NON_CONSTEXPR,  // alpha
+        ArgType::SPECIALIZED,    // m
+        ArgType::SPECIALIZED,    // incx
+        ArgType::CONSTEXPR,      // BLOCK
+    };
+    const Emitted e = emit(kinds,
+                           device_ptr<float>(kAligned),
+                           device_ptr<float>(kAligned),
+                           device_ptr<float>(kMisaligned),
+                           1.0F,
+                           static_cast<int64_t>(4096),
+                           static_cast<int64_t>(1),
+                           32);
+    expect(e.consumed == 7, "every argument must consume exactly one signature slot");
+    expect_token(e, 0, kAlignedPtr, "aligned matrix pointer");
+    expect_token(e, 2, "*fp32", "misaligned output pointer");
+    expect_token(e, 3, "fp32", "a float scalar is unaffected by pointer handling");
+    expect_token(e, 4, kAlignedI32, "a divisible size keeps its ':16' hint");
+    expect_token(e, 5, kEqualToOne, "an equal-to-one stride keeps its existing behavior");
+    expect_token(e, 6, "32", "a constexpr still emits its value");
+    // pointers(3) + alpha(1) + m(1) + incx(0 or 1); the constexpr never joins.
+    expect(e.abi_args == 5 + kEqualToOneAbi, "runtime ABI must hold exactly the non-folded arguments");
+  }
+
+  if (g_failures != 0) {
+    std::cerr << g_failures << " check(s) failed\n";
+    return 1;
+  }
+  std::cout << "test_device_ptr: all checks passed\n";
+  return 0;
+}

--- a/tests/test_standalone_equal_to_one.py
+++ b/tests/test_standalone_equal_to_one.py
@@ -1,0 +1,122 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""An equal-to-one argument must be handed to Triton as a constant only.
+
+Declaring it in the runtime signature as well leaves the compiler with two
+descriptions of the same parameter. Triton folds it either way, so the emitted
+code is identical, but the ASTSource -- and therefore the compilation cache key
+-- stops matching the one the native Python runtime builds for the same call,
+and the C++ and Python paths silently stop sharing compiled kernels.
+
+The test intercepts ASTSource instead of compiling, so it needs no device.
+"""
+
+import importlib.util
+import sys
+
+import triton
+
+
+class _Captured(Exception):
+    """Raised by the ASTSource stub to stop before the real compilation."""
+
+
+def load_module(path):
+    spec = importlib.util.spec_from_file_location("standalone_compile", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def capture_ast_source(module, kernel_path, kernel_name, signature):
+    """Return the signature/constant mappings handed to triton.compiler.ASTSource."""
+    seen = {}
+    original = triton.compiler.ASTSource
+
+    def stub(*args, **kwargs):
+        seen.update(kwargs)
+        raise _Captured
+
+    triton.compiler.ASTSource = stub
+    try:
+        module.compile_a_kernel(kernel_path, kernel_name, signature)
+    except _Captured:
+        pass
+    finally:
+        triton.compiler.ASTSource = original
+
+    assert seen, "ASTSource was never constructed"
+    constants = seen.get("constexprs", seen.get("constants"))
+    assert constants is not None, "ASTSource received neither constexprs nor constants"
+    return seen["signature"], constants
+
+
+def lookup(mapping, index, name):
+    """Read an entry regardless of the key convention of the Triton version."""
+    for key in ((index,), index, name):
+        if key in mapping:
+            return mapping[key]
+    return None
+
+
+def main():
+    script_path, fixture_path = sys.argv[1], sys.argv[2]
+    module = load_module(script_path)
+
+    # strided_copy_kernel(out_ptr, stride, size, BLOCK) with stride == 1.
+    signature, constants = capture_ast_source(
+        module, fixture_path, "strided_copy_kernel", "*fp32:16,i32:1,i32:16,64"
+    )
+
+    stride_type = lookup(signature, 1, "stride")
+    assert stride_type in (None, "constexpr"), (
+        "an equal-to-one argument must not also be declared as a runtime type "
+        f"(got {stride_type!r}); this splits the compilation cache key away from "
+        "the one the native Python runtime builds"
+    )
+    assert (
+        lookup(constants, 1, "stride") == 1
+    ), "an equal-to-one argument must be a constant of 1"
+
+    # Neighbouring arguments must be untouched: a divisibility hint stays a
+    # runtime argument, and a real constexpr keeps its value.
+    assert (
+        lookup(signature, 2, "size") == "i32"
+    ), "a divisible-by-16 argument stays a runtime i32"
+    assert (
+        lookup(constants, 2, "size") is None
+    ), "a divisible-by-16 argument is not a constant"
+    assert lookup(constants, 3, "BLOCK") == 64, "a constexpr keeps its value"
+
+    # Without an equal-to-one argument the same parameter stays a runtime i32.
+    signature, constants = capture_ast_source(
+        module, fixture_path, "strided_copy_kernel", "*fp32:16,i32,i32:16,64"
+    )
+    assert (
+        lookup(signature, 1, "stride") == "i32"
+    ), "a plain integer stays a runtime argument"
+    assert (
+        lookup(constants, 1, "stride") is None
+    ), "a plain integer must not become a constant"
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add typed-launch support for callers that hold raw device addresses instead of `at::Tensor`.

This PR:

- Introduces `TritonDevicePtr`, which pairs a raw address with a runtime `TritonDType`.
- Supports typed pointers, integer device handles, explicit element types, and runtime-selected dtypes such as FP8.
- Gives raw pointers the same signature, specialization, and cache behavior as equivalent tensor arguments.
- Uses pointer-specific alignment specialization so address `1` is not incorrectly folded into a constant.
- Removes equal-to-one arguments from the runtime signature to keep C++ and Python compilation cache keys consistent.
- Adds coverage for device pointer handling and equal-to-one signature generation.

## Tests

- Added `device_ptr_cpp`
- Added `standalone_equal_to_one`